### PR TITLE
Distribute vegasflow on clusters with dask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ dmypy.json
 _*.c
 *.o
 *.so
+
+# dask
+dask-worker-space
+*.out

--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -58,6 +58,8 @@ to send the jobs to.
 An example can be found in the `examples/cluster_dask.py <https://github.com/N3PDF/vegasflow/blob/master/examples/cluster_dask.py>`_ file where
 the `SLURM <https://slurm.schedmd.com/documentation.html>`_ cluster is used as an example
 
+.. note:: When the distributing capabilities of dask are being useful, ``VegasFlow`` "forfeits" control of the devices in which to run, trusting ``TensorFlow``'s defaults. To run, for instance, two GPUs in one single node while using dask the user should send two separate dask jobs, each targetting a different GPU.
+
 Global configuration
 ====================
 

--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -45,6 +45,19 @@ We also provide a convenience wrapper ``vegas_wrapper`` that allows to run the w
 
     result = vegas_wrapper(example_integrand, dimensions, n_iter, ncalls)
 
+Running in distributed systems
+==============================
+
+``vegasflow`` implements an easy interface to distributed system via
+the `dask <https://dask.org/>`_ library.
+In order to enable it is enough by calling the ``set_distribute`` method
+of the instantiated integrator class.
+This method takes a `dask_jobqueue <https://jobqueue.dask.org/en/latest/>`_
+to send the jobs to.
+
+An example can be found in the `examples/cluster_dask.py <https://github.com/N3PDF/vegasflow/blob/master/examples/cluster_dask.py>`_ file where
+the `SLURM <https://slurm.schedmd.com/documentation.html>`_ cluster is used as an example
+
 Global configuration
 ====================
 
@@ -69,6 +82,10 @@ In order to use the CPU you can hide the GPU by setting
 If you have a set-up with more than one GPU you can select which one you will
 want to use for the integration by setting the environment variable to the
 right device, e.g., ``export CUDA_VISIBLE_DEVICES=0``.
+
+
+
+
 
 .. _eager-label:
 

--- a/examples/cluster_dask.py
+++ b/examples/cluster_dask.py
@@ -1,0 +1,30 @@
+"""
+    Example: cluster usage
+
+    Basic example of running a VegasFlow job on a distributed system
+    using dask and the SLURMCluster backend
+"""
+
+from dask_jobqueue import SLURMCluster  # pylint: disable=import-error
+from vegasflow.vflow import VegasFlow
+import tensorflow as tf
+
+
+def integrand(xarr, **kwargs):
+    return tf.reduce_sum(xarr, axis=1)
+
+
+if __name__ == "__main__":
+    cluster = SLURMCluster(
+        memory="2g",
+        processes=1,
+        cores=4,
+        queue="<partition_name>",
+        project="<accout_name>",
+        job_extra=["--get-user-env", "--nodes=1"],
+    )
+
+    mc_instance = VegasFlow(4, int(1e7), events_limit=int(1e6))
+    mc_instance.set_distribute(cluster)
+    mc_instance.compile(integrand)
+    mc_instance.run_integration(5)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name='vegasflow',
             'dask',
             'distribute',
             'dask-jobqueue',
+            'tensorflow>2.2', # dask needs a more-pickable tensorflow
             ],
           },
       python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ setup(name='vegasflow',
           'benchmark' : [
             'vegas', # Lepage's Vegas for benchmarking
             ],
+          'distribute' : [
+            'dask',
+            'distribute',
+            ],
           },
       python_requires='>=3.6',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(name='vegasflow',
           'distribute' : [
             'dask',
             'distribute',
+            'dask-jobqueue',
             ],
           },
       python_requires='>=3.6',

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -113,8 +113,8 @@ class MonteCarloFlow(ABC):
         self._history = []
         self.n_events = n_events
         self._events_per_run = min(events_limit, n_events)
-        self.lock = threading.Lock()
         if list_devices:
+            self.lock = threading.Lock()
             # List all devices from the list that can be found by tensorflow
             devices = []
             for device_type in list_devices:
@@ -127,6 +127,7 @@ class MonteCarloFlow(ABC):
             # Generate the pool of workers
             self.pool = joblib.Parallel(n_jobs=len(devices), prefer="threads")
         else:
+            self.lock = None
             self.devices = None
 
     @property

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -381,7 +381,8 @@ class DistributedVegasFlow(VegasFlow):
             events_left -= self.events_per_run
 
         # Enable the slurm cluster
-        from dask_jobqueue import SLURMCluster
+        from dask_jobqueue import SLURMCluster # pylint: disable=import-error
+
         cluster = SLURMCluster(memory='2g', processes=1, cores=4,
                 queue='<partition_name>', project='<accout_name>',
                 job_extra=['--get-user-env',

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -380,7 +380,7 @@ class DistributedVegasFlow(VegasFlow):
             events_to_do.append(ncalls)
             events_left -= self.events_per_run
 
-        from dask.distributed import Client
+        from dask.distributed import Client # pylint: disable=import-error
         client = Client()
         accumulators_future = client.map(self.device_run, events_to_do, percentages)
         import vegasflow

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -24,23 +24,23 @@ FBINS = float_me(BINS_MAX)
 @tf.function
 def generate_random_array(rnds, divisions):
     """
-        Generates the Vegas random array for any number of events
+    Generates the Vegas random array for any number of events
 
-        Parameters
-        ----------
-            rnds: array shaped (None, n_dim)
-                Random numbers used as an input for Vegas
-            divisions: array shaped (n_dim, BINS_MAX)
-                vegas grid
+    Parameters
+    ----------
+        rnds: array shaped (None, n_dim)
+            Random numbers used as an input for Vegas
+        divisions: array shaped (n_dim, BINS_MAX)
+            vegas grid
 
-        Returns
-        -------
-            x: array (None, n_dim)
-                Vegas random output
-            div_index: array (None, n_dim)
-                division index in which each (n_dim) set of random numbers fall
-            w: array (None,)
-                Weight of each set of (n_dim) random numbers
+    Returns
+    -------
+        x: array (None, n_dim)
+            Vegas random output
+        div_index: array (None, n_dim)
+            division index in which each (n_dim) set of random numbers fall
+        w: array (None,)
+            Weight of each set of (n_dim) random numbers
     """
     # Get the boundaries of the random numbers
     #     reg_i = fzero
@@ -80,23 +80,32 @@ def generate_random_array(rnds, divisions):
 @tf.function
 def refine_grid_per_dimension(t_res_sq, subdivisions):
     """
-        Modifies the boundaries for the vegas grid for a given dimension
+    Modifies the boundaries for the vegas grid for a given dimension
 
-        Parameters
-        ----------
-            `t_res_sq`: tensor
-                array of results squared per bin
-            `subdivision`: tensor
-                current boundaries for the grid
+    Parameters
+    ----------
+        `t_res_sq`: tensor
+            array of results squared per bin
+        `subdivision`: tensor
+            current boundaries for the grid
 
-        Returns
-        -------
-            `new_divisions`: tensor
-                array with the new boundaries of the grid
+    Returns
+    -------
+        `new_divisions`: tensor
+            array with the new boundaries of the grid
     """
     # Define some constants
-    paddings = tf.constant([[1, 1],])
-    tmp_meaner = tf.fill([BINS_MAX - 2,], float_me(3.0))
+    paddings = tf.constant(
+        [
+            [1, 1],
+        ]
+    )
+    tmp_meaner = tf.fill(
+        [
+            BINS_MAX - 2,
+        ],
+        float_me(3.0),
+    )
     meaner = tf.pad(tmp_meaner, paddings, constant_values=2.0)
     # Pad the vector of results
     res_padded = tf.pad(t_res_sq, paddings)
@@ -114,14 +123,14 @@ def refine_grid_per_dimension(t_res_sq, subdivisions):
     ###### Auxiliary functions for the while loop
     @tf.function
     def while_check(bin_weight, *args):
-        """ Checks whether the bin has enough weight
-        to beat the average """
+        """Checks whether the bin has enough weight
+        to beat the average"""
         return bin_weight < ave_t
 
     @tf.function
     def while_body(bin_weight, n_bin, cur, prev):
-        """ Fills the bin weight until it surpassed the avg
-        once it's done, returns the limits of the last bin """
+        """Fills the bin weight until it surpassed the avg
+        once it's done, returns the limits of the last bin"""
         n_bin += 1
         bin_weight += wei_t[n_bin]
         prev = cur
@@ -139,7 +148,10 @@ def refine_grid_per_dimension(t_res_sq, subdivisions):
     prev = fzero
     for _ in range(BINS_MAX - 1):
         bin_weight, n_bin, cur, prev = tf.while_loop(
-            while_check, while_body, (bin_weight, n_bin, cur, prev), parallel_iterations=1,
+            while_check,
+            while_body,
+            (bin_weight, n_bin, cur, prev),
+            parallel_iterations=1,
         )
         bin_weight -= ave_t
         delta = (cur - prev) * bin_weight / wei_t[n_bin]
@@ -182,7 +194,7 @@ class VegasFlow(MonteCarloFlow):
         self.recompile()
 
     def save_grid(self, file_name):
-        """ Save the `divisions` array in a json file
+        """Save the `divisions` array in a json file
 
         Parameters
         ----------
@@ -205,7 +217,7 @@ class VegasFlow(MonteCarloFlow):
             json.dump(json_dict, f, indent=True)
 
     def load_grid(self, file_name=None, numpy_grid=None):
-        """ Load the `divisions` array from a json file
+        """Load the `divisions` array from a json file
         or from a numpy_array
 
         Parameters
@@ -260,7 +272,7 @@ class VegasFlow(MonteCarloFlow):
         self.divisions.assign(numpy_grid)
 
     def refine_grid(self, arr_res2):
-        """ Receives an array with the values of the integral squared per
+        """Receives an array with the values of the integral squared per
         bin per dimension (`arr_res2.shape = (n_dim, self.grid_bins)`)
         and reshapes the `divisions` attribute accordingly
 
@@ -275,7 +287,7 @@ class VegasFlow(MonteCarloFlow):
             self.divisions[j, :].assign(new_divisions)
 
     def _run_event(self, integrand, ncalls=None):
-        """ Runs one step of Vegas.
+        """Runs one step of Vegas.
 
         Parameters
         ----------
@@ -339,7 +351,7 @@ class VegasFlow(MonteCarloFlow):
         self.iteration_content = self._iteration_content
 
     def recompile(self):
-        """ Forces recompilation with the same arguments that have
+        """Forces recompilation with the same arguments that have
         previously been used for compilation"""
         if self.compile_args is None:
             raise RuntimeError("recompile was called without ever having called compile")
@@ -352,56 +364,8 @@ class VegasFlow(MonteCarloFlow):
         return res, sigma
 
 
-class DistributedVegasFlow(VegasFlow):
-
-    def __init__(self, n_dim, n_events, **kwargs):
-        if "list_devices" in kwargs:
-            logger.warning("DistributedVegasFlow does not accept an input list of devices")
-            kwargs.pop("list_devices")
-        super().__init__(n_dim, n_events, list_devices = None, **kwargs)
-
-    def run_event(self, **kwargs):
-        """ Overrides ``MonteCarlo.run_event`` to distribute
-        the workload using dask
-        """
-        if not self.event:
-            raise RuntimeError("Compile must be ran before running any iterations")
-        # Run until there are no events left to do
-        events_left = self.n_events
-        events_to_do = []
-        percentages = []
-        # Fill the array of event distribution
-        # If using multiple devices, decide the policy for job sharing
-        pc = 0.0
-        while events_left > 0:
-            ncalls = min(events_left, self.events_per_run)
-            pc += ncalls / self.n_events * 100
-            percentages.append(pc)
-            events_to_do.append(ncalls)
-            events_left -= self.events_per_run
-
-        # Enable the slurm cluster
-        from dask_jobqueue import SLURMCluster # pylint: disable=import-error
-
-        cluster = SLURMCluster(memory='2g', processes=1, cores=4,
-                queue='<partition_name>', project='<accout_name>',
-                job_extra=['--get-user-env',
-                    '--nodes=1'])
-
-        cluster.scale(jobs=5)
-
-        from dask.distributed import Client # pylint: disable=import-error
-        client = Client(cluster)
-        accumulators_future = client.map(self.device_run, events_to_do, percentages)
-        import vegasflow
-        result_future = client.submit(vegasflow.monte_carlo._accumulate, accumulators_future)
-        result = result_future.result()
-        # Close client
-        client.close()
-        return result
-        
 def vegas_wrapper(integrand, n_dim, n_iter, total_n_events, **kwargs):
-    """ Convenience wrapper
+    """Convenience wrapper
 
     Parameters
     ----------
@@ -416,11 +380,3 @@ def vegas_wrapper(integrand, n_dim, n_iter, total_n_events, **kwargs):
         `sigma`: monte carlo error
     """
     return wrapper(VegasFlow, integrand, n_dim, n_iter, total_n_events, **kwargs)
-
-if __name__ == "__main__":
-    tf.config.experimental_run_functions_eagerly(True)
-    def symgauss(xarr, **kwargs):
-        return tf.reduce_sum(xarr, axis=1)
-    mc_instance = DistributedVegasFlow(4, int(1e7), events_limit=int(1e6))
-    mc_instance.compile(symgauss)
-    mc_instance.run_integration(5)


### PR DESCRIPTION
This seems to work in one single computer. I'll try it in galileo as soon as I am able to.

As far as I understand the point of the matter is to have a `run_event` per distributed system where the dask client connects to the appropriate one.

The way it will work is by sending a job per chunk of data while the master node / central server collects all data and gives you the results.

At first I thought "this is so simple we should use this instead of joblib" but then I realised not only complicates _pickability_ and device selection but also the `distribute` package from pip was not working in dom... (the one from Arch is) so for now I prefer to keep it as a completely separate option.