### PR TITLE
Add a conditions generator

### DIFF
--- a/src/vegasflow/tests/test_utils.py
+++ b/src/vegasflow/tests/test_utils.py
@@ -2,9 +2,12 @@
 
 import numpy as np
 import tensorflow as tf
+import pytest
 
 from vegasflow.configflow import DTYPEINT
 from vegasflow.utils import consume_array_into_indices
+
+from vegasflow.utils import generate_condition_function
 
 
 def test_consume_array_into_indices():
@@ -25,3 +28,39 @@ def test_consume_array_into_indices():
     for val, i in zip(input_array, indices):
         check_result[i] += val
     np.testing.assert_allclose(check_result, result)
+
+def util_check(np_mask, tf_mask, tf_ind):
+    np.testing.assert_array_equal(np_mask, tf_mask)
+    np.testing.assert_array_equal(np_mask.nonzero()[0], tf_ind)
+
+def test_generate_condition_function():
+    """ Tests generate_condition_function and its errors """
+    masks = 4 # Always > 2
+    vals = 15
+    np_masks = np.random.randint(2, size=(masks, vals), dtype=np.bool)
+    tf_masks = [tf.constant(i, dtype=tf.bool) for i in np_masks]
+    # Generate the functions for and and or
+    f_and = generate_condition_function(masks, 'and')
+    f_or = generate_condition_function(masks, 'or')
+    # Get the numpy and tf results
+    np_ands = np.all(np_masks, axis=0)
+    np_ors = np.any(np_masks, axis=0)
+    tf_ands, idx_ands = f_and(*tf_masks)
+    tf_ors, idx_ors = f_or(*tf_masks)
+    # Check the values are the same
+    util_check(np_ands, tf_ands, idx_ands)
+    util_check(np_ors, tf_ors, idx_ors)
+    # Check a combination
+    f_comb = generate_condition_function(3, ['and', 'or'])
+    np_comb = np_masks[0] & np_masks[1] | np_masks[2]
+    tf_comb, idx_comb = f_comb(*tf_masks[:3])
+    util_check(np_comb, tf_comb, idx_comb)
+    # Check failures
+    with pytest.raises(ValueError):
+        generate_condition_function(1, 'and')
+    with pytest.raises(ValueError):
+        generate_condition_function(5, 'bad_condition')
+    with pytest.raises(ValueError):
+        generate_condition_function(5, ['or', 'and'])
+    with pytest.raises(ValueError):
+        generate_condition_function(3, ['or', 'bad_condition'])

--- a/src/vegasflow/tests/test_utils.py
+++ b/src/vegasflow/tests/test_utils.py
@@ -31,7 +31,9 @@ def test_consume_array_into_indices():
 
 def util_check(np_mask, tf_mask, tf_ind):
     np.testing.assert_array_equal(np_mask, tf_mask)
-    np.testing.assert_array_equal(np_mask.nonzero()[0], tf_ind)
+    # Numpy returns things the other way around
+    np_indices = np.array(np_mask.nonzero()).T
+    np.testing.assert_array_equal(np_indices, tf_ind)
 
 def test_generate_condition_function():
     """ Tests generate_condition_function and its errors """

--- a/src/vegasflow/utils.py
+++ b/src/vegasflow/utils.py
@@ -2,8 +2,8 @@
     This module contains tensorflow_compiled utilities
 """
 
+from vegasflow.configflow import DTYPEINT, fzero, int_me
 import tensorflow as tf
-from vegasflow.configflow import DTYPEINT, fzero
 
 
 @tf.function
@@ -35,3 +35,93 @@ def consume_array_into_indices(input_arr, indices, result_size):
     res_tmp = tf.where(eq, input_arr, fzero)
     final_result = tf.reduce_sum(res_tmp, axis=1)
     return final_result
+
+def generate_condition_function(n_mask, condition='and'):
+    """ Generates a function that takes a number of masks
+    and returns a combination of all n_masks for the given condition.
+
+    It is possible to pass a list of allowed conditions, in that case
+    the length of the list should be n_masks - 1 and will be apply
+    sequentially.
+
+    Note that for 2 masks you can directly use & and |
+
+
+    >>> from vegasflow.utils import generate_condition_function
+    >>> import tensorflow as tf
+    >>> f_cond = generate_condition_function(2, condition='or')
+    >>> t_1 = tf.constant([True, False, True])
+    >>> t_2 = tf.constant([False, False, True])
+    >>> full_mask, indices = f_cond(t_1, t_2)
+    >>> print(f"{full_mask=}\n{indices=}")
+    full_mask=<tf.Tensor: shape=(3,), dtype=bool, numpy=array([ True, False,  True])>
+    indices=<tf.Tensor: shape=(2,), dtype=int32, numpy=array([0, 2], dtype=int32)>
+    >>> f_cond = generate_condition_function(3, condition=['or', 'and'])
+    >>> t_1 = tf.constant([True, False, True])
+    >>> t_2 = tf.constant([False, False, True])
+    >>> t_3 = tf.constant([True, False, False])
+    >>> full_mask, indices = f_cond(t_1, t_2, t_3)
+    >>> print(f"{full_mask=}\n{indices=}")
+    full_mask=<tf.Tensor: shape=(3,), dtype=bool, numpy=array([ True, False, False])>
+    indices=<tf.Tensor: shape=(), dtype=int32, numpy=0>
+    
+
+    Parameters
+    ----------
+    `n_mask`: int
+        Number of masks the function should accept
+    `condition`: str (default='and')
+        Condition to apply to all masks. Accepted values are: and, or
+
+    Returns
+    -------
+    `condition_to_idx`: function
+        function(*masks) -> full_mask, true indices
+    """
+    allowed_conditions = {
+            'and': tf.math.logical_and,
+            'or' : tf.math.logical_or
+            }
+    allo = list(allowed_conditions.keys())
+
+    # Check that the user is not asking for anything weird
+    if n_mask < 2:
+        raise ValueError(f"At least two masks needed to generate a wrapper")
+    elif isinstance(condition, str):
+        if condition not in allowed_conditions:
+            raise ValueError(f"Wrong condition {condition}, allowed values are {allo}")
+        is_list = False
+    else:
+        if len(condition) != n_mask - 1:
+            raise ValueError(f"Wrong number of conditions for {n_mask} masks: {len(condition)}")
+        for cond in condition:
+            if cond not in allowed_conditions:
+                raise ValueError(f"Wrong condition {cond}, allowed values are {allo}")
+        is_list = True
+
+    def py_condition(*masks):
+        """ Receives a list of conditions and returns a result mask
+        and the list of indices in which the result mask is True
+
+        Returns
+        -------
+            `res`: tf.bool
+                Mask that combines all masks
+            `indices`: tf.int
+                Indices in which `res` is True
+        """
+        if is_list:
+            res = masks[0]
+            for i, cond in enumerate(condition):
+                res = allowed_conditions[cond](res, masks[i+1])
+        elif condition == 'and':
+            res = tf.math.reduce_all(masks, axis=0)
+        elif condition == 'or':
+            res = tf.math.reduce_any(masks, axis=0)
+        indices = int_me(tf.squeeze(tf.where(res)))
+        return res, indices
+
+    signature = n_mask*[tf.TensorSpec(shape=[None], dtype=tf.bool)]
+
+    condition_to_idx = tf.function(py_condition, input_signature=signature)
+    return condition_to_idx

--- a/src/vegasflow/utils.py
+++ b/src/vegasflow/utils.py
@@ -46,7 +46,6 @@ def generate_condition_function(n_mask, condition='and'):
 
     Note that for 2 masks you can directly use & and |
 
-
     >>> from vegasflow.utils import generate_condition_function
     >>> import tensorflow as tf
     >>> f_cond = generate_condition_function(2, condition='or')
@@ -55,7 +54,9 @@ def generate_condition_function(n_mask, condition='and'):
     >>> full_mask, indices = f_cond(t_1, t_2)
     >>> print(f"{full_mask=}\n{indices=}")
     full_mask=<tf.Tensor: shape=(3,), dtype=bool, numpy=array([ True, False,  True])>
-    indices=<tf.Tensor: shape=(2,), dtype=int32, numpy=array([0, 2], dtype=int32)>
+    indices=<tf.Tensor: shape=(2, 1), dtype=int32, numpy=
+    array([[0],
+        [2]], dtype=int32)>
     >>> f_cond = generate_condition_function(3, condition=['or', 'and'])
     >>> t_1 = tf.constant([True, False, True])
     >>> t_2 = tf.constant([False, False, True])
@@ -63,7 +64,8 @@ def generate_condition_function(n_mask, condition='and'):
     >>> full_mask, indices = f_cond(t_1, t_2, t_3)
     >>> print(f"{full_mask=}\n{indices=}")
     full_mask=<tf.Tensor: shape=(3,), dtype=bool, numpy=array([ True, False, False])>
-    indices=<tf.Tensor: shape=(), dtype=int32, numpy=0>
+    indices=<tf.Tensor: shape=(1, 1), dtype=int32, numpy=array([[0]], dtype=int32)>
+
     
 
     Parameters
@@ -118,7 +120,7 @@ def generate_condition_function(n_mask, condition='and'):
             res = tf.math.reduce_all(masks, axis=0)
         elif condition == 'or':
             res = tf.math.reduce_any(masks, axis=0)
-        indices = int_me(tf.squeeze(tf.where(res)))
+        indices = int_me(tf.where(res))
         return res, indices
 
     signature = n_mask*[tf.TensorSpec(shape=[None], dtype=tf.bool)]


### PR DESCRIPTION
This adds an auxiliary function that can be used to generate cuts: `generate_condition_function`

For instance, the following code will create a function `f_cond` that upon being called with three conditions returns a boolean mask of the three conditions (as requested by the keyword `condition`) and the indices in which these are `True` which is often useful.

```python
from vegasflow.utils import generate_condition_function
f_cond = generate_condition_function(3, condition = ['and', 'or'])
t_1 = pt_jet1 > 15
t_2 = pt_jet2 > 15
t_3 = rapidity_jet_1 < 4
full_mask, indices = f_cond(t_1, t_2, t_3)
```

This PR is pointing to PR #56 

I'll add the docs directly in #58 though