### PR TITLE
Add example for using vegasflow as a rng

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -85,6 +85,26 @@ we can ignore that.
 Finally, ``generate_random_array`` returns also the probability distribution
 of the random points (i.e., the weight they carry).
 
+For convenience we include sampler wrappers which directly return a trained
+reference to the `generate_random_array` method:
+
+.. code-block:: python
+  
+  from vegasflow import vegas_sampler
+  
+  sampler = vegas_sampler(my_complicated_fun, n_dim, n_events)
+  rnds, _, px = sampler(100)
+
+
+It is possible to change the number of training steps (default 5) or to retrieve
+a reference to the sampler class instead to the sampler method by using keyword
+arguments.
+
+.. code-block:: python
+  
+  sampler_class = vegas_sampler(my_complicated_fun, n_dim, n_events, training_steps=1, return_class=True)
+  rnds, _, px = sampler_class.generate_random_array(100)
+
 
 Integrating a numpy function
 ============================

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -24,7 +24,7 @@ integrand.
 
 .. code-block:: python
 
-    from VegasFlow import vegas_wrapper
+    from vegasflow import vegas_wrapper
     import tensorflow as tf
 
     @tf.function
@@ -38,6 +38,52 @@ integrand.
             
 
 You can find a `runnable example of such a basic example in the repository <https://github.com/N3PDF/vegasflow/blob/master/examples/simgauss_tf.py>`_.
+
+
+Using VegasFlow as a clever Random Number Generator
+===================================================
+
+A possible use case for ``VegasFlow`` is to have an function that we don't necessarily
+want to integrate, but that we want to sample from.
+In general, sampling from a function can be very complicated and instead we just want
+to *approximately* sample from it. For that we can use the ``vegasflow`` package
+which instantly give access to all integrator algorithms as function approximators.
+
+In the example below we use importance sampling, from ``VegasFlow`` to approximate
+the function and sample from it, but  the same code will work for any of the
+other implemented integrators.
+
+.. code-block:: python
+      
+    from vegasflow import VegasFlow, run_eager
+    import tensorflow as tf
+
+    run_eager(True)
+    
+    def my_complicated_fun(xarr, **kwargs):
+      return tf.reduce_sum(xarr, axis=1)
+    
+    n_dim = 10
+    n_events = int(1e5)
+    sampler = VegasFlow(n_dim, n_events, verbose=False)
+    sampler.compile(my_complicated_fun)
+    
+    # Now let's train the integrator for 10 iterations
+    _ = sampler.run_integration(10)
+    
+    # Now we can use sampler to generate random numbers
+    rnds, _, px = sampler.generate_random_array(100)
+    
+The first object returned by ``generate_random_array`` are the random points,
+in the case in the example an array of shape ``(100, 10)``, i.e., the first axis
+is the number of requested events and the second axis the number of dimensions.
+
+The second object, ignored in this example, is whatever information the algorithm
+need to train. Since we are just generating random numbers and not training anymore
+we can ignore that.
+
+Finally, ``generate_random_array`` returns also the probability distribution
+of the random points (i.e., the weight they carry).
 
 
 Integrating a numpy function

--- a/src/vegasflow/__init__.py
+++ b/src/vegasflow/__init__.py
@@ -2,7 +2,7 @@
 
 from vegasflow.configflow import int_me, float_me, run_eager
 # Expose the main interfaces
-from vegasflow.vflow import VegasFlow, vegas_wrapper
-from vegasflow.plain import PlainFlow, plain_wrapper
+from vegasflow.vflow import VegasFlow, vegas_wrapper, vegas_sampler
+from vegasflow.plain import PlainFlow, plain_wrapper, plain_sampler
 
 __version__ = "1.2.0"

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -39,7 +39,7 @@ from abc import abstractmethod, ABC
 import joblib
 import numpy as np
 import tensorflow as tf
-from vegasflow.configflow import MAX_EVENTS_LIMIT, DEFAULT_ACTIVE_DEVICES, DTYPE, TECH_CUT, float_me
+from vegasflow.configflow import MAX_EVENTS_LIMIT, DEFAULT_ACTIVE_DEVICES, DTYPE, TECH_CUT, float_me, fone
 
 import logging
 
@@ -177,7 +177,7 @@ class MonteCarloFlow(ABC):
             (n_events, self.n_dim), minval=TECH_CUT, maxval=1.0 - TECH_CUT, dtype=DTYPE
         )
         idx = 0
-        xjac = 1.0/n_events
+        xjac = fone/float_me(n_events)
         return rnds, idx, xjac
 
     #### Abstract methods

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -467,7 +467,7 @@ class MonteCarloFlow(ABC):
 
 
 def wrapper(integrator_class, integrand, n_dim, n_iter, total_n_events, compilable=True):
-    """Convenience wrapper
+    """Convenience wrapper for integration
 
     Parameters
     ----------
@@ -485,3 +485,27 @@ def wrapper(integrator_class, integrand, n_dim, n_iter, total_n_events, compilab
     mc_instance = integrator_class(n_dim, total_n_events)
     mc_instance.compile(integrand, compilable=compilable)
     return mc_instance.run_integration(n_iter)
+
+
+def sampler(integrator_class, integrand, n_dim, total_n_events, training_steps=5, compilable=True, return_class=False):
+    """Convenience wrapper for sampling random numbers
+
+    Parameters
+    ----------
+        `integrator_class`: MonteCarloFlow inherited class
+        `integrand`: tf.function
+        `n_dim`: number of dimensions
+        `n_events`: number of events per iteration
+        `training_steps`: number of training_iterations
+        `return_class`: whether to return the full instance of the class or only the random method
+
+    Returns
+    -------
+        `sampler`: a reference to the generate_random_array method of the integrator class
+    """
+    mc_instance = integrator_class(n_dim, total_n_events, verbose=False)
+    mc_instance.compile(integrand, compilable=compilable)
+    _ = mc_instance.run_integration(training_steps, log_time=False)
+    if return_class:
+        return mc_instance
+    return mc_instance.generate_random_array

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -114,7 +114,6 @@ class MonteCarloFlow(ABC):
         self._verbose = verbose
         self._history = []
         self.n_events = n_events
-        self._xjac = float_me(1.0/n_events)
         self._events_per_run = min(events_limit, n_events)
         self.distribute = False
         if list_devices:
@@ -178,7 +177,8 @@ class MonteCarloFlow(ABC):
             (n_events, self.n_dim), minval=TECH_CUT, maxval=1.0 - TECH_CUT, dtype=DTYPE
         )
         idx = 0
-        return rnds, idx, self._xjac
+        xjac = 1.0/n_events
+        return rnds, idx, xjac
 
     #### Abstract methods
     @abstractmethod

--- a/src/vegasflow/plain.py
+++ b/src/vegasflow/plain.py
@@ -3,7 +3,7 @@
 """
 
 from vegasflow.configflow import DTYPE, fone, fzero
-from vegasflow.monte_carlo import MonteCarloFlow, wrapper
+from vegasflow.monte_carlo import MonteCarloFlow, wrapper, sampler
 import tensorflow as tf
 
 
@@ -37,6 +37,10 @@ class PlainFlow(MonteCarloFlow):
         return res, sigma
 
 
-def plain_wrapper(*args):
+def plain_wrapper(*args, **kwargs):
     """ Wrapper around PlainFlow """
-    return wrapper(PlainFlow, *args)
+    return wrapper(PlainFlow, *args, **kwargs)
+
+def plain_sampler(*args, **kwargs):
+    """ Wrapper sampler around PlainFlow """
+    return sampler(PlainFlow, *args, **kwargs)

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -109,3 +109,15 @@ def test_PlainFlow():
     plain_instance = instance_and_compile(PlainFlow)
     result = plain_instance.run_integration(n_iter)
     check_is_one(result)
+
+
+def test_rng_generation(n_events=100):
+    plain_sampler = instance_and_compile(PlainFlow)
+    rnds, _, px = plain_sampler.generate_random_array(n_events)
+    np.testing.assert_equal(rnds.shape, (100,2))
+    np.testing.assert_equal(px.numpy(), 1.0/n_events)
+    vegas_sampler = instance_and_compile(VegasFlow)
+    vegas_sampler.run_integration(2)
+    rnds, _, px = vegas_sampler.generate_random_array(n_events)
+    np.testing.assert_equal(rnds.shape, (100,2))
+    np.testing.assert_equal(px.shape, (100,))

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -11,7 +11,7 @@ import numpy as np
 import tensorflow as tf
 
 from vegasflow.configflow import BINS_MAX, ALPHA
-from vegasflow.monte_carlo import MonteCarloFlow, wrapper
+from vegasflow.monte_carlo import MonteCarloFlow, wrapper, sampler
 from vegasflow.utils import consume_array_into_indices
 
 import logging
@@ -383,3 +383,19 @@ def vegas_wrapper(integrand, n_dim, n_iter, total_n_events, **kwargs):
         `sigma`: monte carlo error
     """
     return wrapper(VegasFlow, integrand, n_dim, n_iter, total_n_events, **kwargs)
+
+def vegas_sampler(*args, **kwargs):
+    """Convenience wrapper for sampling random numbers
+
+    Parameters
+    ----------
+        `integrand`: tf.function
+        `n_dim`: number of dimensions
+        `n_events`: number of events per iteration
+        `training_steps`: number of training_iterations
+
+    Returns
+    -------
+        `sampler`: a reference to the generate_random_array method of the integrator class
+    """
+    return sampler(VegasFlow, *args, **kwargs)


### PR DESCRIPTION
Deals with issue #66. It just adds an example (and fixes a bug when it was used in this way!) which I think can be an use case for this library. Specially once #64 and rtbms are added.