### PR TITLE
enable tests for python 3.9

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        pip install . --pre
+        pip install .
     - name: Lint with pylint
       run: |
         pip install pylint

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install . --pre
     - name: Lint with pylint
       run: |
         pip install pylint

--- a/src/vegasflow/__init__.py
+++ b/src/vegasflow/__init__.py
@@ -5,4 +5,4 @@ from vegasflow.configflow import int_me, float_me, run_eager
 from vegasflow.vflow import VegasFlow, vegas_wrapper, vegas_sampler
 from vegasflow.plain import PlainFlow, plain_wrapper, plain_sampler
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
Since [Tensorflow](https://github.com/tensorflow/tensorflow/releases/tag/v2.5.0-rc1) has python support and there are now two releases candidates in pip I guess it makes sense to at least enable the tests and check whether something breaks.

Not 100% sure about merging and pushing the package to pypi before it's an official release and not just a release candidate. I guess in the worst case I'll merge once I've been using it for a few weeks if I don´t find any problems.

Closes #62  