### PR TITLE
Add a signature discovery and trace option

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -174,7 +174,8 @@ by using the CFFI library as you can see in `this <https://github.com/N3PDF/vega
     # Now you can read up the compiled C code as a python library
     from _integrand_cffi import ffi, lib
     
-    def integrand(xarr, n_dim, **kwargs):
+    def integrand(xarr, **kwargs):
+        n_dim = xarr.shape[-1]
         result = np.empty(n_events, dtype=DTYPE.as_numpy_dtype)
         x_flat = xarr.numpy().flatten()
         

--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -111,7 +111,7 @@ These functions are wrappers around ``tf.cast`` `🔗 <https://www.tensorflow.or
     
     constant = float_me(0.1)
     
-    def example_integrand(xarr, n_dim=None, weight=None):
+    def example_integrand(xarr, weight=None):
       s = tf.reduce_sum(xarr, axis=1)
       result = tf.pow(constant/s, 2)
       return result
@@ -359,7 +359,7 @@ This is a crucial step (and the only fixed step) as this tensor will be accumula
         cummulator_tensor.assign(new_histograms)
 
     @tf.function
-    def integrand_example(xarr, n_dim=None, weight=fone):
+    def integrand_example(xarr, weight=fone):
         # some complicated calculation that generates 
         # a final_result and some histogram values:
         final_result = tf.constant(42, dtype=tf.float64)

--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -77,7 +77,7 @@ the integration algorithm).
     import numpy as np
     
     def example_integrand(xarr, weight=None):
-      s = np.pow(xarr, axis=1)
+      s = np.sum(xarr, axis=1)
       result = np.square(0.1/s)
       return result
       

--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -44,7 +44,7 @@ using the ``tf.function`` decorator.
 
     import tensorflow as tf
     
-    def example_integrand(xarr, n_dim=None, weight=None):
+    def example_integrand(xarr, weight=None):
       s = tf.reduce_sum(xarr, axis=1)
       result = tf.pow(0.1/s, 2)
       return result
@@ -76,17 +76,16 @@ the integration algorithm).
 
     import numpy as np
     
-    def example_integrand(xarr, n_dim=None, weight=None):
+    def example_integrand(xarr, weight=None):
       s = np.pow(xarr, axis=1)
       result = np.square(0.1/s)
       return result
       
     vegas_instance.compile(example_integrand, compilable=False)
 
-
-.. note:: Integrands must accept the keyword arguments ``n_dim`` and ``weight``, as the integrators
-   will try to pass those argument when convenient. It is however possible to construct integrands
-   that accept only the array of random number ``xarr``, see :ref:`simple-label`
+.. note:: Integrands must always accept as first argument the random number (``xarr``)
+  and can also accept the keyword argument ``weight``. The ``compile`` method of the integration
+   will try to find the most adequate signature in each situation.
 
 
 It is also possible to completely avoid compilation,
@@ -140,42 +139,6 @@ The full list of integration algorithms and wrappers can be consulted at: :ref:`
 
 Tips and Tricks
 ===============
-
-.. _simple-label:
-
-Improving results by simplifying the integrand
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In the above example the integrand receives the keyword arguments `n_dim` and `xjac`.
-Although these are useful for instance for filling histograms or dimensional-dependent integrands,
-these extra argument can harm the performance of the integration when they are not being used.
-
-It is possible to instantiate ``VegasFlow`` algorithms with ``simplify_signature``.
-In this case the integrand will only receive the array of random numbers and, in exchange for this
-loss of flexibility, the function will be retraced less often.
-For more details in what function retracing entails we direct you to the `TensorFlow documentation <https://www.tensorflow.org/api_docs/python/tf/function>`_.
-
-.. code-block:: python
-
-    from vegasflow import VegasFlow, float_me
-    import tensorflow as tf
-
-    def example_integrand(xarr):
-        c = float_me(0.1)
-        s = tf.reduce_sum(xarr)
-        result = tf.pow(c/s)
-        return result
-
-    dimensions = 3
-    n_calls = int(1e7)
-    # Create an instance of the VegasFlow class
-    vegas_instance = VegasFlow(dimensions, n_calls, simplify_signature = True)
-    # Compile the function to be integrated
-    vegas_instance.compile(example_integrand)
-    # Compute the result after a number of iterations
-    n_iter = 5
-    result = vegas_instance.run_integration(n_iter)
-    
 
 Seeding the random number generator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/intalg.rst
+++ b/doc/source/intalg.rst
@@ -35,7 +35,10 @@ Once that is generated it is possible to register an integrand by calling the ``
 .. code-block:: python
 
     def example_integrand(x, **kwargs):
-        return x
+        y = 0.0
+        for d in range(dims):
+            y += x[:,d]
+        return y
 
     vegas_instance.compile(example_integrand)
 
@@ -44,6 +47,7 @@ After each iteration the grid will be refined, producing more points (and hence 
 
 .. code-block:: python
 
+    n_iter = 3
     result = vegas_instance.run_integration(n_iter)
 
 The output variable, in this example named ``result``, is a tuple variable where the first element is the result of the integration while the second element is the error of the integration.
@@ -103,7 +107,7 @@ The usage pattern is similar to :ref:`vegas-label`.
 .. code-block:: python
 
     from vegasflow import PlainFlow
-    plain_instance = PlainFlow(dimensions, ncalls)
+    plain_instance = PlainFlow(dims, n_calls)
     plain_instance.compile(example_integrand)
     plain_instance.run_integration(n_iter)
 

--- a/examples/asian_options_tf.py
+++ b/examples/asian_options_tf.py
@@ -29,7 +29,7 @@ zero = tf.constant(0.0, dtype=DTYPE)
 
 
 @tf.function
-def example_integrand(xarr, n_dim=None, **kwargs):
+def example_integrand(xarr, **kwargs):
     """Asian options test function"""
     sum1 = tf.reduce_sum(ndtri(xarr), axis=1)
     a = S0 * tf.exp((r-sigma2/2) + sigma*sqrtdt*sum1)

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -1,7 +1,7 @@
 """
     Example: basic integration
 
-    Very basic example with a simple integrand, uses simplify_signature
+    Very basic example with a simple integrand
 """
 
 from vegasflow import VegasFlow, float_me, run_eager
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     """Testing several different integrations"""
     print(f"VEGAS MC, ncalls={ncalls}:")
     start = time.time()
-    vegas_instance = VegasFlow(dim, ncalls, simplify_signature=True, events_limit=int(7e4))
+    vegas_instance = VegasFlow(dim, ncalls, events_limit=int(7e4))
     vegas_instance.compile(symgauss)
     result = vegas_instance.run_integration(n_iter)
     end = time.time()

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -37,3 +37,6 @@ if __name__ == "__main__":
     result = vegas_instance.run_integration(n_iter)
     end = time.time()
     print(f"Vegas took: time (s): {end-start}")
+    print("Change the number of events and freeze the grid...")
+    vegas_instance.freeze_grid()
+    vegas_instance.run_integration(n_iter)

--- a/examples/cluster_dask.py
+++ b/examples/cluster_dask.py
@@ -14,7 +14,7 @@ def integrand(xarr, **kwargs):
     return tf.reduce_sum(xarr, axis=1)
 
 
-if __name__ == "__main__":
+if __name__ == "__main_aa_":
     cluster = SLURMCluster(
         memory="2g",
         processes=1,

--- a/examples/cluster_dask.py
+++ b/examples/cluster_dask.py
@@ -14,7 +14,7 @@ def integrand(xarr, **kwargs):
     return tf.reduce_sum(xarr, axis=1)
 
 
-if __name__ == "__main_aa_":
+if __name__ == "__main__":
     cluster = SLURMCluster(
         memory="2g",
         processes=1,

--- a/examples/drellyan_lo_tf.py
+++ b/examples/drellyan_lo_tf.py
@@ -240,7 +240,7 @@ def build_luminosity(x1, x2):
 
 
 @tf.function
-def drellyan(xarr, n_dim=None, weight=None, **kwargs):
+def drellyan(xarr, weight=None, **kwargs):
     """Single-top (t-channel) at LO"""
     psw, flux, p0, p1, p2, p3, x1, x2 = make_event(xarr)
     wgts = evaluate_matrix_element_square(p0, p1, p2, p3)

--- a/examples/drellyan_lo_tf.py
+++ b/examples/drellyan_lo_tf.py
@@ -240,7 +240,7 @@ def build_luminosity(x1, x2):
 
 
 @tf.function
-def drellyan(xarr, **kwargs):
+def drellyan(xarr, n_dim=None, weight=None, **kwargs):
     """Single-top (t-channel) at LO"""
     psw, flux, p0, p1, p2, p3, x1, x2 = make_event(xarr)
     wgts = evaluate_matrix_element_square(p0, p1, p2, p3)

--- a/examples/example_eager.py
+++ b/examples/example_eager.py
@@ -20,10 +20,9 @@ n_iter = 5
 
 
 @tf.function
-def symgauss_sigmoid(xarr, n_dim=None, **kwargs):
+def symgauss_sigmoid(xarr, **kwargs):
     """symgauss test function"""
-    if n_dim is None:
-        n_dim = xarr.shape[-1]
+    n_dim = xarr.shape[-1]
     a = 0.1
     pref = pow(1.0 / a / np.sqrt(np.pi), n_dim)
     coef = np.sum(np.arange(1, 101))

--- a/examples/example_pineappl.py
+++ b/examples/example_pineappl.py
@@ -82,7 +82,7 @@ def fill(grid, x1, x2, q2, yll, weight):
     grid.fill_array(x1, x2, q2, zeros, yll, zeros, weight)
 
 
-def fill_grid(xarr, n_dim=None, weight=1, **kwargs):
+def fill_grid(xarr, weight=1, **kwargs):
     s, t, u, x1, x2, jacobian = hadronic_pspgen(xarr, 10.0, 7000.0)
 
     ptl = tf.sqrt((t * u / s))

--- a/examples/histogram_ex.py
+++ b/examples/histogram_ex.py
@@ -19,24 +19,22 @@ HISTO_BINS = 2
 
 
 def generate_integrand(cummulator_tensor):
-    """ 
+    """
     This function will generate an integrand function
     which will already hold a reference to the tensor to accumulate
     """
 
     @tf.function
     def histogram_collector(results, variables):
-        """ This function will receive a tensor (result)
-        and the variables corresponding to those integrand results 
-        In the example integrand below, these corresponds to 
+        """This function will receive a tensor (result)
+        and the variables corresponding to those integrand results
+        In the example integrand below, these corresponds to
             `final_result` and `histogram_values` respectively.
         `current_histograms` instead is the current value of the histogram
-        which will be overwritten """
+        which will be overwritten"""
         # Fill a histogram with HISTO_BINS (2) bins, (0 to 0.5, 0.5 to 1)
         # First generate the indices with TF
-        indices = tf.histogram_fixed_width_bins(
-            variables, [fzero, fone], nbins=HISTO_BINS
-        )
+        indices = tf.histogram_fixed_width_bins(variables, [fzero, fone], nbins=HISTO_BINS)
         t_indices = tf.transpose(indices)
         # Then consume the results with the utility we provide
         partial_hist = consume_array_into_indices(results, t_indices, HISTO_BINS)
@@ -44,16 +42,11 @@ def generate_integrand(cummulator_tensor):
         new_histograms = partial_hist + current_histograms
         cummulator_tensor.assign(new_histograms)
 
-    def integrand_example(xarr, n_dim=None, weight=fone):
-        """ Example of function which saves histograms """
-        if n_dim is None:
-            n_dim = xarr.shape[-1]
-        if n_dim < hst_dim:
-            raise ValueError(
-                f"The number of dimensions has to be greater than {hst_dim} for this example"
-            )
+    def integrand_example(xarr, weight=fone):
+        """Example of function which saves histograms"""
+        n_dim = xarr.shape[-1]
         a = tf.constant(0.1, dtype=DTYPE)
-        n100 = tf.cast(100 * n_dim, dtype=DTYPE)
+        n100 = tf.cast(100 * dim, dtype=DTYPE)
         pref = tf.pow(1.0 / a / np.sqrt(np.pi), n_dim)
         coef = tf.reduce_sum(tf.range(n100 + 1))
         coef += tf.reduce_sum(tf.square((xarr - 1.0 / 2.0) / a), axis=1)
@@ -69,6 +62,10 @@ def generate_integrand(cummulator_tensor):
 
 if __name__ == "__main__":
     """Testing histogram generation"""
+    if dim < hst_dim:
+        raise ValueError(
+            f"The number of dimensions has to be greater than {hst_dim} for this example"
+        )
     print(f"Plain MC, ncalls={ncalls}:")
     start = time.time()
     # First we create the tensor in which to accumulate the histogra

--- a/examples/simgauss_cffi.py
+++ b/examples/simgauss_cffi.py
@@ -49,9 +49,8 @@ ffibuilder.compile(verbose=True)
 
 from _symgauss_cffi import ffi, lib
 
-def symgauss(xarr, n_dim=None, **kwargs):
-    if n_dim is None:
-        n_dim = xarr.shape[-1]
+def symgauss(xarr, **kwargs):
+    n_dim = xarr.shape[-1]
     n_events = xarr.shape[0]
 
     res = np.empty(n_events, dtype = DTYPE.as_numpy_dtype)

--- a/examples/simgauss_tf.py
+++ b/examples/simgauss_tf.py
@@ -19,10 +19,9 @@ n_iter = 5
 
 
 @tf.function
-def symgauss(xarr, n_dim=None, **kwargs):
+def symgauss(xarr, **kwargs):
     """symgauss test function"""
-    if n_dim is None:
-        n_dim = xarr.shape[-1]
+    n_dim = xarr.shape[-1]
     a = tf.constant(0.1, dtype=DTYPE)
     n100 = tf.cast(100 * n_dim, dtype=DTYPE)
     pref = tf.pow(1.0 / a / np.sqrt(np.pi), n_dim)

--- a/examples/singletop_lo_tf.py
+++ b/examples/singletop_lo_tf.py
@@ -261,7 +261,7 @@ def build_luminosity(x1, x2):
 
 
 @tf.function
-def singletop(xarr, n_dim=None, **kwargs):
+def singletop(xarr, **kwargs):
     """Single-top (t-channel) at LO"""
     psw, flux, p0, p1, p2, p3, x1, x2 = make_event(xarr)
     wgts = evaluate_matrix_element_square(p0, p1, p2, p3)

--- a/src/vegasflow/__init__.py
+++ b/src/vegasflow/__init__.py
@@ -5,4 +5,4 @@ from vegasflow.configflow import int_me, float_me, run_eager
 from vegasflow.vflow import VegasFlow, vegas_wrapper, vegas_sampler
 from vegasflow.plain import PlainFlow, plain_wrapper, plain_sampler
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -429,7 +429,7 @@ class MonteCarloFlow(ABC):
             raw_integrand = integrand
             if "weight" in args:
 
-                def integrand(xarr, weight=None, **kwargs):
+                def integrand(xarr, weight=None, **kwargs):  # pylint: disable=function-redefined
                     return raw_integrand(xarr, n_dim=self.n_dim, weight=weight)
 
             else:

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -160,7 +160,7 @@ class MonteCarloFlow(ABC):
         """Number of events to run in a single iteration"""
         self._n_events = val
         # Reset `events_per_run` if needed
-        self.event = self._events_limit
+        self.events_per_run = self._events_limit
 
     @property
     def events_per_run(self):

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -36,6 +36,7 @@ import inspect
 import time
 import copy
 import threading
+import logging
 from abc import abstractmethod, ABC
 import joblib
 import numpy as np
@@ -44,13 +45,10 @@ from vegasflow.configflow import (
     MAX_EVENTS_LIMIT,
     DEFAULT_ACTIVE_DEVICES,
     DTYPE,
-    DTYPEINT,
     TECH_CUT,
     float_me,
-    fone,
 )
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +108,7 @@ class MonteCarloFlow(ABC):
         n_dim,
         n_events,
         events_limit=MAX_EVENTS_LIMIT,
-        list_devices=DEFAULT_ACTIVE_DEVICES,
+        list_devices=DEFAULT_ACTIVE_DEVICES,  # pylint: disable=dangerous-default-value
         verbose=True,
     ):
         # Save some parameters
@@ -293,8 +291,8 @@ class MonteCarloFlow(ABC):
         """
         try:
             import dask.distributed  # pylint: disable=import-error
-        except ImportError:
-            raise ImportError("Install dask and distributed to use `set_distribute`")
+        except ImportError as e:
+            raise ImportError("Install dask and distributed to use `set_distribute`") from e
         if self.devices is not None:
             logger.warning("`set_distribute` overrides any previous device configuration")
         self.list_devices = None
@@ -436,7 +434,7 @@ class MonteCarloFlow(ABC):
 
             else:
 
-                def integrand(xarr, **kwargs):
+                def integrand(xarr, **kwargs):  # pylint: disable=function-redefined
                     return raw_integrand(xarr, n_dim=self.n_dim, **kwargs)
 
             # Remove n_dim
@@ -468,7 +466,7 @@ class MonteCarloFlow(ABC):
                     "Provide a `signature` if you want to compile with an specific signature"
                 )
                 # Drop signature completely
-                signature_content = False
+                signature = False
             if arg == "weight":
                 if signature:
                     signature.append(tf.TensorSpec(shape=[None], dtype=DTYPE))

--- a/src/vegasflow/plain.py
+++ b/src/vegasflow/plain.py
@@ -21,10 +21,7 @@ class PlainFlow(MonteCarloFlow):
         # Generate all random number for this iteration
         rnds, _, xjac = self._generate_random_array(n_events)
         # Compute the integrand
-        if self._pass_weight:
-            tmp = integrand(rnds, weight=xjac) * xjac
-        else:
-            tmp = integrand(rnds) * xjac
+        tmp = integrand(rnds, weight=xjac) * xjac
         tmp2 = tf.square(tmp)
         # Accumulate the current result
         res = tf.reduce_sum(tmp)

--- a/src/vegasflow/plain.py
+++ b/src/vegasflow/plain.py
@@ -21,7 +21,10 @@ class PlainFlow(MonteCarloFlow):
         # Generate all random number for this iteration
         rnds, _, xjac = self._generate_random_array(n_events)
         # Compute the integrand
-        tmp = integrand(rnds, n_dim=self.n_dim, weight=xjac) * xjac
+        if self._pass_weight:
+            tmp = integrand(rnds, weight=xjac) * xjac
+        else:
+            tmp = integrand(rnds) * xjac
         tmp2 = tf.square(tmp)
         # Accumulate the current result
         res = tf.reduce_sum(tmp)

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -73,9 +73,21 @@ def test_VegasFlow():
         result = vegas_instance.run_integration(n_iter)
         check_is_one(result)
 
+    # Change the number of events
     vegas_instance.n_events = 2 * ncalls
     new_result = vegas_instance.run_integration(n_iter)
     check_is_one(new_result)
+
+    # Unfreeze the grid
+    vegas_instance.unfreeze_grid()
+    new_result = vegas_instance.run_integration(n_iter)
+    check_is_one(new_result)
+
+    # And change the number of calls again
+    vegas_instance.n_events = 3 * ncalls
+    new_result = vegas_instance.run_integration(n_iter)
+    check_is_one(new_result)
+
 
 def test_VegasFlow_save_grid():
     tmp_filename = tempfile.mktemp()

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -22,7 +22,7 @@ n_iter = 4
 
 
 def example_integrand(xarr, weight=None):
-    """ Example function that integrates to 1 """
+    """Example function that integrates to 1"""
     n_dim = xarr.shape[-1]
     a = tf.constant(0.1, dtype=DTYPE)
     n100 = tf.cast(100 * n_dim, dtype=DTYPE)
@@ -34,16 +34,21 @@ def example_integrand(xarr, weight=None):
 
 
 def instance_and_compile(Integrator, mode=0):
-    """ Wrapper for convenience """
+    """Wrapper for convenience"""
     if mode == 0:
         integrand = example_integrand
     elif mode == 1:
+
         def integrand(xarr, n_dim=None):
             return example_integrand(xarr)
+
     elif mode == 2:
+
         def integrand(xarr):
             return example_integrand(xarr)
+
     elif mode == 3:
+
         def integrand(xarr, n_dim=None, weight=None):
             return example_integrand(xarr, weight=None)
 
@@ -53,7 +58,7 @@ def instance_and_compile(Integrator, mode=0):
 
 
 def check_is_one(result, sigmas=3):
-    """ Wrapper for convenience """
+    """Wrapper for convenience"""
     res = result[0]
     err = result[1] * sigmas
     # Check that it passes by {sigmas} number of sigmas
@@ -68,6 +73,9 @@ def test_VegasFlow():
         result = vegas_instance.run_integration(n_iter)
         check_is_one(result)
 
+    vegas_instance.n_events = 2 * ncalls
+    new_result = vegas_instance.run_integration(n_iter)
+    check_is_one(new_result)
 
 def test_VegasFlow_save_grid():
     tmp_filename = tempfile.mktemp()
@@ -118,10 +126,17 @@ def test_VegasFlow_load_grid():
 
 
 def test_PlainFlow():
+    # TODO: move the loop to hypothesis...
     for mode in range(4):
         plain_instance = instance_and_compile(PlainFlow, mode)
         result = plain_instance.run_integration(n_iter)
         check_is_one(result)
+
+    # Use the last instance to check that changing the number of events
+    # don't change the result
+    plain_instance.n_events = 2 * ncalls
+    new_result = plain_instance.run_integration(n_iter)
+    check_is_one(new_result)
 
 
 def helper_rng_tester(sampling_function, n_events):
@@ -133,7 +148,7 @@ def helper_rng_tester(sampling_function, n_events):
 
 
 def test_rng_generation(n_events=100):
-    """ Test that the random generation genrates the correct type of arrays """
+    """Test that the random generation genrates the correct type of arrays"""
     plain_sampler_instance = instance_and_compile(PlainFlow)
     _, px = helper_rng_tester(plain_sampler_instance.generate_random_array, n_events)
     np.testing.assert_equal(px.numpy(), 1.0 / n_events)

--- a/src/vegasflow/tests/test_utils.py
+++ b/src/vegasflow/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_generate_condition_function():
     """ Tests generate_condition_function and its errors """
     masks = 4 # Always > 2
     vals = 15
-    np_masks = np.random.randint(2, size=(masks, vals), dtype=np.bool)
+    np_masks = np.random.randint(2, size=(masks, vals), dtype=bool)
     tf_masks = [tf.constant(i, dtype=tf.bool) for i in np_masks]
     # Generate the functions for and and or
     f_and = generate_condition_function(masks, 'and')

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -182,7 +182,6 @@ class VegasFlow(MonteCarloFlow):
         # If training is True, the grid will be changed after every iteration
         # otherwise it will be frozen
         self.train = train
-        self._compilation_arguments = None
 
         # Initialize grid
         self.grid_bins = BINS_MAX + 1
@@ -351,20 +350,6 @@ class VegasFlow(MonteCarloFlow):
         if self.train:
             self.refine_grid(arr_res2)
         return res, sigma
-
-    def compile(self, integrand, **kwargs):
-        """Save the compilation arguments, if the grid is frozen at any point
-        a recompilaton will be triggered
-        """
-        self._compilation_arguments = (integrand, kwargs)
-        super().compile(integrand, **kwargs)
-
-    def _recompile(self):
-        """Forces recompilation with the same arguments that have
-        previously been used for compilation"""
-        if self._compilation_arguments is None:
-            raise RuntimeError("recompile was called without ever having called compile")
-        self.compile(self._compilation_arguments[0], **self._compilation_arguments[1])
 
     def _run_iteration(self):
         """Runs one iteration of the Vegas integrator"""

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -323,10 +323,7 @@ class VegasFlow(MonteCarloFlow):
         x, ind, xjac = self._generate_random_array(n_events)
 
         # Now compute the integrand
-        if self._pass_weight:
-            tmp = xjac * integrand(x, weight=xjac)
-        else:
-            tmp = xjac * integrand(x)
+        tmp = xjac * integrand(x, weight=xjac)
         tmp2 = tf.square(tmp)
 
         # Compute the final result for this step


### PR DESCRIPTION
This adds signatures in a couple of places and adds a signature discovery option as well.

Needs a few test before it can be merged, but it should be fine.

This should fix #73 and it #72 should be easy to implement on top of this as well (the ability to retrace should help when adding an accuracy target). 

Tested with madflow so it should be fine to go.