### PR TITLE
Differentiability interface

### DIFF
--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -192,19 +192,21 @@ The way ``TensorFlow`` seeding works can be consulted here `here <https://www.te
 Constructing differentiable and compilable integrations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-While there is no currently a supported interface to generate integrations that can be used
-inside a TensorFlow library (for instance, inside a Neural Network) and ``VegasFlow`` behaves
-(with respect to any graphs) as the top-level library.
-It is possible to get the desired behavior so that an integration with ``VegasFlow`` can be used
-inside a `tf.function` environment (and be differentiated).
+An interface to generate integration callabales that can be used inside a TensorFlow library (for instance, inside a Neural Network)
+is provided through the ``make_differentiable`` method.
+This method will make the necessary changes to the integration, mainly
+such as freezing the grid and ensuring that only one device is used,
+and it returns a callable function that can be used as just another TensorFlow function.
 
-Some approximations are however necessary,
-first of all, we consider in this example that we are interested in the integration itself
-and not in the specific of the grid-refining process.
-Therefore, any derivatives (or actual integration) need only to care about the last iteration.
-In this case, one can just call `run_event` instead of `run_iteration`.
-While `run_iteration` returns the total result after running a number of iterations,
-`run_event` runs the `ncall` number of events just once:
+In the following example, we generate a function to be integrated
+(which can depend on external input through the mutable variable ``z``).
+Afterwards, the function is compiled (and trained) as a normal integrand,
+until we call ``make_differentiable``.
+At that point the grid is frozen and a ``runner`` is returned which will
+run a batch of ``n_calls`` points of the integrator.
+The ``runner`` can now be used inside a ``tf.function``-compiled function
+and gradients can be computed as shown below.
+
 
 .. code-block:: python
 
@@ -214,25 +216,37 @@ While `run_iteration` returns the total result after running a number of iterati
     dims = 4
     n_calls = int(1e4)
     vegas_instance = VegasFlow(dims, n_calls, verbose=False)
+    z = tf.Variable(float_me(1.0))
+
+    def example_integrand(x, **kwargs):
+        y = tf.reduce_sum(x, axis=1)
+        return y*z
+
+    vegas_instance.compile(example_integrand)
+    # Now we run a few iterations to train the grid, but we can bin them
+    _ = vegas_instance.run_integration(3)
+
+    runner = vegas_instance.make_differentiable()
 
     @tf.function
     def some_complicated_function(x):
-        
-        def example_integrand(z, **kwargs):
-            y = 0.0
-            for d in range(dims):
-                y += z[:,d] + x
-            return y
-
-        integration_result, error, _ = vegas_instance._run_event(example_integrand, n_calls)
-        return integration_result
+        integration_result, error, _ = runner()
+        return x*integration_result
 
     my_x = float_me(4.0)
     result = some_complicated_function(my_x)
 
-    with tf.GradientTape() as tape:
-        y = some_complicated_function(my_x)
-    tape.gradient(my_x, y)
+    def compute_and_print_gradient():
+        with tf.GradientTape() as tape:
+            tape.watch(my_x)
+            y = some_complicated_function(my_x)
+
+        grad = tape.gradient(y, my_x)
+        print(f"Result {y.numpy():.3}, gradient: {grad.numpy():.3}")
+
+    compute_and_print_gradient()
+    z.assign(float_me(4.0))
+    compute_and_print_gradient()
 
 Running in distributed systems
 ==============================

--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -203,7 +203,7 @@ In the following example, we generate a function to be integrated
 Afterwards, the function is compiled (and trained) as a normal integrand,
 until we call ``make_differentiable``.
 At that point the grid is frozen and a ``runner`` is returned which will
-run a batch of ``n_calls`` points of the integrator.
+run the integration result.
 The ``runner`` can now be used inside a ``tf.function``-compiled function
 and gradients can be computed as shown below.
 

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -335,7 +335,7 @@ class MonteCarloFlow(ABC):
         """Modifies the attributes of the integration so that it can be compiled inside
         Tensorflow functions (and, therefore, gradients calculated)
         Returns a reference to `run_event`, a method that upon calling it with no arguments
-        will produce results and unceranties for a ncalls number of events
+        will produce results and uncertainties for an intergation iteration of ncalls number of events
         """
         if self.distribute:
             raise ValueError("Differentiation is not compatible with distribution")

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -357,7 +357,7 @@ class MonteCarloFlow(ABC):
                 self.devices = {main_device: True}
 
         if self.event:
-            logger.warning("You should call `make_differentiable` before compiling, recompiling...")
+            logger.warning("Recompiling...")
             self._recompile()
 
         return self.run_event

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -250,7 +250,7 @@ class MonteCarloFlow(ABC):
 
     @abstractmethod
     def _run_event(self, integrand, ncalls=None):
-        """Run one single event of the Monte Carlo integration
+        """Run one single event (batch of calls) of the Monte Carlo integration
         the output must be a tuple"""
         result = self.event()
         return result, pow(result, 2)
@@ -536,14 +536,14 @@ class MonteCarloFlow(ABC):
                 return tf_integrand(xarr, n_dim=self.n_dim, **kwargs)
             return tf_integrand(xarr, **kwargs)
 
-        def run_event(**kwargs):
+        def batch_events(**kwargs):
             """Pass any arguments to the underlying integrand"""
             return self._run_event(new_integrand, **kwargs)
 
         if compilable:
-            self.event = tf.function(run_event)
+            self.event = tf.function(batch_events)
         else:
-            self.event = run_event
+            self.event = batch_events
 
         if trace:
             self.trace()

--- a/src/vegasflow/tests/test_gradients.py
+++ b/src/vegasflow/tests/test_gradients.py
@@ -1,0 +1,82 @@
+"""
+    Tests the gradients of the different algorithms
+"""
+
+from vegasflow import float_me
+from vegasflow import VegasFlow, VegasFlowPlus, PlainFlow
+import tensorflow as tf
+import numpy as np
+
+
+def generate_integrand(variable):
+    """Generate an integrand that depends on an input variable"""
+
+    def example_integrand(x):
+        y = tf.reduce_sum(x, axis=1)
+        return y * variable
+
+    return example_integrand
+
+
+def generate_differentiable_function(iclass, integrand, dims=3, n_calls=int(1e5)):
+    """Generates a function that depends on the result of a Monte Carlo integral
+    of ``integrand`` using the class iclass (in differentiable form) as integrator
+    """
+    integrator_instance = iclass(dims, n_calls, verbose=False)
+    runner = integrator_instance.make_differentiable()
+    integrator_instance.compile(integrand)
+
+    def some_complicated_function(x):
+        integration_result, *_ = runner()
+        return x * integration_result
+
+    compiled_fun = tf.function(some_complicated_function)
+    # Compile
+    _ = compiled_fun(float_me(4.0))
+    # Train
+    _ = integrator_instance.run_integration(2)
+    return compiled_fun
+
+
+def wrapper_test(iclass, x_point=5.0, alpha=10):
+    """Wrapper for all integrators"""
+    # Create a variable
+    z = tf.Variable(float_me(1.0))
+    # Create an integrand that depends on this variable
+    integrand = generate_integrand(z)
+    # Now create a function that depends on its integration
+    fun = generate_differentiable_function(iclass, integrand)
+
+    x0 = float_me(x_point)
+    with tf.GradientTape() as tape:
+        tape.watch(x0)
+        y1 = fun(x0)
+
+    grad_1 = tape.gradient(y1, x0)
+
+    # Change the value of the variable
+    z.assign(z.numpy() * alpha)
+
+    with tf.GradientTape() as tape:
+        tape.watch(x0)
+        y2 = fun(x0)
+
+    grad_2 = tape.gradient(y2, x0)
+
+    # Test that the gradient works as expected
+    np.testing.assert_allclose(grad_1 * alpha, grad_2, rtol=1e-2)
+
+
+def test_gradient_Vegasflow():
+    """"Test one can compile and generate gradients with VegasFlow"""
+    wrapper_test(VegasFlow)
+
+# 
+# def test_gradient_VegasflowPlus():
+#     """"Test one can compile and generate gradients with VegasFlowPlus"""
+#     wrapper_test(VegasFlowPlus)
+
+
+def test_gradient_PlainFlow():
+    """"Test one can compile and generate gradients with PlainFlow"""
+    wrapper_test(PlainFlow)

--- a/src/vegasflow/tests/test_gradients.py
+++ b/src/vegasflow/tests/test_gradients.py
@@ -2,7 +2,7 @@
     Tests the gradients of the different algorithms
 """
 
-from vegasflow import float_me
+from vegasflow import float_me, run_eager
 from vegasflow import VegasFlow, VegasFlowPlus, PlainFlow
 import tensorflow as tf
 import numpy as np
@@ -18,34 +18,37 @@ def generate_integrand(variable):
     return example_integrand
 
 
-def generate_differentiable_function(iclass, integrand, dims=3, n_calls=int(1e5)):
+def generate_differentiable_function(iclass, integrand, dims=3, n_calls=int(1e5), i_kwargs=None):
     """Generates a function that depends on the result of a Monte Carlo integral
     of ``integrand`` using the class iclass (in differentiable form) as integrator
     """
-    integrator_instance = iclass(dims, n_calls, verbose=False)
-    runner = integrator_instance.make_differentiable()
+    if i_kwargs is None:
+        i_kwargs = {}
+    integrator_instance = iclass(dims, n_calls, verbose=False, **i_kwargs)
     integrator_instance.compile(integrand)
+    # Train
+    _ = integrator_instance.run_integration(2)
+    # Now make it differentiable/compilable
+    runner = integrator_instance.make_differentiable()
 
     def some_complicated_function(x):
         integration_result, *_ = runner()
         return x * integration_result
 
     compiled_fun = tf.function(some_complicated_function)
-    # Compile
+    # Compile the function
     _ = compiled_fun(float_me(4.0))
-    # Train
-    _ = integrator_instance.run_integration(2)
     return compiled_fun
 
 
-def wrapper_test(iclass, x_point=5.0, alpha=10):
+def wrapper_test(iclass, x_point=5.0, alpha=10, integrator_kwargs=None):
     """Wrapper for all integrators"""
     # Create a variable
     z = tf.Variable(float_me(1.0))
     # Create an integrand that depends on this variable
     integrand = generate_integrand(z)
     # Now create a function that depends on its integration
-    fun = generate_differentiable_function(iclass, integrand)
+    fun = generate_differentiable_function(iclass, integrand, i_kwargs=integrator_kwargs)
 
     x0 = float_me(x_point)
     with tf.GradientTape() as tape:
@@ -68,15 +71,16 @@ def wrapper_test(iclass, x_point=5.0, alpha=10):
 
 
 def test_gradient_Vegasflow():
-    """"Test one can compile and generate gradients with VegasFlow"""
+    """ "Test one can compile and generate gradients with VegasFlow"""
     wrapper_test(VegasFlow)
 
-# 
-# def test_gradient_VegasflowPlus():
-#     """"Test one can compile and generate gradients with VegasFlowPlus"""
-#     wrapper_test(VegasFlowPlus)
+
+def test_gradient_VegasflowPlus():
+    """ "Test one can compile and generate gradients with VegasFlowPlus"""
+    wrapper_test(VegasFlowPlus)
+    wrapper_test(VegasFlowPlus, integrator_kwargs={"adaptive": True})
 
 
 def test_gradient_PlainFlow():
-    """"Test one can compile and generate gradients with PlainFlow"""
+    """ "Test one can compile and generate gradients with PlainFlow"""
     wrapper_test(PlainFlow)

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -231,6 +231,13 @@ class VegasFlow(MonteCarloFlow):
         divisions_np = subdivision_np.repeat(n_dim).reshape(-1, n_dim).T
         self.divisions = tf.Variable(divisions_np, dtype=DTYPE)
 
+    def make_differentiable(self):
+        """Freeze the grid if the function is to be called within a graph"""
+        if self.train:
+            logger.warning("Freezing the grid")
+            self.freeze_grid()
+        return super().make_differentiable()
+
     def freeze_grid(self):
         """Stops the grid from refining any more"""
         self.train = False

--- a/src/vegasflow/vflowplus.py
+++ b/src/vegasflow/vflowplus.py
@@ -89,12 +89,13 @@ class VegasFlowPlus(VegasFlow):
             logger.info("Events per device limit set to %d", n_events)
             events_limit = n_events
         elif events_limit < n_events:
-            logger.warning("VegasFlowPlus needs to hold all events in memory at once, "
-                    "setting the `events_limit` to be equal to `n_events=%d`", n_events)
+            logger.warning(
+                "VegasFlowPlus needs to hold all events in memory at once, "
+                "setting the `events_limit` to be equal to `n_events=%d`",
+                n_events,
+            )
             events_limit = n_events
         super().__init__(n_dim, n_events, train, events_limit=events_limit, **kwargs)
-
-
 
         # Save the initial number of events
         self._init_calls = n_events
@@ -229,6 +230,10 @@ class VegasFlowPlus(VegasFlow):
     def run_event(self, tensorize_events=None, **kwargs):
         """Tensorizes the number of events
         so they are not python or numpy primitives if self._adaptive=True"""
+        if "n_ev" not in kwargs:
+            # This function is being called from the outside
+            # force 'n_ev' in
+            kwargs["n_ev"] = self.n_ev
         return super().run_event(tensorize_events=self._adaptive, **kwargs)
 
 

--- a/src/vegasflow/vflowplus.py
+++ b/src/vegasflow/vflowplus.py
@@ -7,6 +7,7 @@
     The main interface is the `VegasFlowPlus` class.
 """
 from itertools import product
+from functools import partial
 import numpy as np
 import tensorflow as tf
 
@@ -139,6 +140,11 @@ class VegasFlowPlus(VegasFlow):
         if self._adaptive:
             logger.warning("Variable number of events requires function signatures all across")
 
+    def make_differentiable(self):
+        """Overrides make_differentiable to make sure the runner has a reference to n_ev"""
+        runner = super().make_differentiable()
+        return partial(runner, n_ev = self.n_ev)
+
     def redistribute_samples(self, arr_var):
         """Receives an array with the variance of the integrand in each
         hypercube and recalculate the samples per hypercube according
@@ -230,10 +236,6 @@ class VegasFlowPlus(VegasFlow):
     def run_event(self, tensorize_events=None, **kwargs):
         """Tensorizes the number of events
         so they are not python or numpy primitives if self._adaptive=True"""
-        if "n_ev" not in kwargs:
-            # This function is being called from the outside
-            # force 'n_ev' in
-            kwargs["n_ev"] = self.n_ev
         return super().run_event(tensorize_events=self._adaptive, **kwargs)
 
 


### PR DESCRIPTION
This should address #76

The idea (subject to change as a I write documentation and find out I've done something wrong) is to have a method `make_differentiable()` that ensures that the integration can be run inside a `tf.function` decorator. For now that part is working (and can be differentiated). This PR is missing:

- [x] Documentation
- [x] Tests

Anyway, below an example:

```python
from vegasflow import VegasFlow, float_me
import tensorflow as tf

dims = 4
n_calls = int(1e4)
vegas_instance = VegasFlow(dims, n_calls, verbose=False)
z = tf.Variable(float_me(1.0))


def example_integrand(x, **kwargs):
    y = tf.reduce_sum(x, axis=1)
    return y*z

runner = vegas_instance.make_differentiable()
vegas_instance.compile(example_integrand)

# Now we run a few iterations to train the grid, but we can bin them
_ = vegas_instance.run_integration(3)

@tf.function
def some_complicated_function(x):
    integration_result, error, _ = runner()
    return x*integration_result

my_x = float_me(4.0)
result = some_complicated_function(my_x)

def compute_and_print_gradient():
    with tf.GradientTape() as tape:
        tape.watch(my_x)
        y = some_complicated_function(my_x)

    grad = tape.gradient(y, my_x)
    print(f"Result {y.numpy():.3}, gradient: {grad.numpy():.3}")

compute_and_print_gradient()
z.assign(float_me(4.0))
compute_and_print_gradient()
```


What "make differentiable" actually entails is making sure the integration is running in one single device. I guess forfeiting control of the devices to TensorFlow would work just the same but as we tested in the past, the distribution strategies of TensorFlow do not work very well for our purposes and that's the reason we are managing it ourselves.
And, if at some point there's one strategy that works it would be as easy as emptying the list of devices (because in that case it forfeits all control to TensorFlow).


There is a second option (to keep the multi-device capabilities working in this situation) which is wrapping the management in this case in a `py_function` but then `VegasFlow` would be managing a threadpool inside a Tensorflow pool of threads over which it has no control and would probably ending up summoning creatures from down below. I'm open to suggestions though, maybe there's an easy way of doing this I'm missing.