### PR TITLE
Integrate vector functions

### DIFF
--- a/examples/multidimensional_integral.py
+++ b/examples/multidimensional_integral.py
@@ -27,7 +27,7 @@ def test_function(xarr):
 
 if __name__ == "__main__":
     print("Testing a multidimensional integration")
-    vegas = VegasFlow(dim, ncalls)
+    vegas = VegasFlow(dim, ncalls, main_dimension=1)
     vegas.compile(test_function)
     all_results, all_err = vegas.run_integration(2)
     try:

--- a/examples/multidimensional_integral.py
+++ b/examples/multidimensional_integral.py
@@ -1,0 +1,40 @@
+"""
+    Example: basic multidimensional integral
+
+    The output of the function is not an scalar but a vector v.
+    In this case it is necessary to tell Vegas which is the main dimension
+    (i.e., the output dimension the grid should adapt to)
+
+    Note that the integrand should have an output of the same shape as the tensor of random numbers
+    the shape of the tensor of random numbers and of the output is (nevents, ndim) 
+"""
+from vegasflow import VegasFlow, run_eager
+
+run_eager()
+import tensorflow as tf
+
+# MC integration setup
+dim = 3
+ncalls = int(1e4)
+n_iter = 5
+
+
+@tf.function
+def test_function(xarr):
+    res = tf.square((xarr - 1.0) ** 2)
+    return tf.exp(-res[:, 1])
+
+
+if __name__ == "__main__":
+    print("Testing a multidimensional integration")
+    vegas = VegasFlow(dim, ncalls)
+    vegas.compile(test_function)
+    all_results, all_err = vegas.run_integration(2)
+    try:
+        for result, error in zip(all_results, all_err):
+            print(f"{result = :.5} +- {error:.5}")
+    except TypeError:
+        # So that the example works also if the integrand is made scalar
+        result = all_results
+        error = all_err
+        print(f"{result = :.5} +- {error:.5}")

--- a/examples/multidimensional_integral.py
+++ b/examples/multidimensional_integral.py
@@ -22,7 +22,7 @@ n_iter = 5
 @tf.function
 def test_function(xarr):
     res = tf.square((xarr - 1.0) ** 2)
-    return tf.exp(-res[:, 1])
+    return tf.exp(-res)
 
 
 if __name__ == "__main__":

--- a/examples/multiple_integrals.py
+++ b/examples/multiple_integrals.py
@@ -5,6 +5,10 @@
 
     The example integrands are variations of the Genz functions definged in
     Novak et al, 1999 (J. of Comp and Applied Maths, 112 (1999) 215-228 and implemented from http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.123.8452&rep=rep1&type=pdf
+
+    Note, when possible the ``multidimensional_integral.py`` features should be utilized
+    as then the error computation is automatically taken into account by the algorithms
+    in VegasFlow instead of having to implement it by hand.
 """
 import vegasflow
 from vegasflow.configflow import DTYPE

--- a/src/vegasflow/__init__.py
+++ b/src/vegasflow/__init__.py
@@ -1,6 +1,6 @@
 """Monte Carlo integration with Tensorflow"""
 
-from vegasflow.configflow import int_me, float_me, run_eager
+from vegasflow.configflow import int_me, float_me, run_eager, DTYPE, DTYPEINT
 
 # Expose the main interfaces
 from vegasflow.vflow import VegasFlow, vegas_wrapper, vegas_sampler

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -105,6 +105,8 @@ class MonteCarloFlow(ABC):
         `list_devices`: list of device type to use (use `None` to do the tensorflow default)
     """
 
+    _CAN_RUN_VECTORIAL = False
+
     def __init__(
         self,
         n_dim,
@@ -256,10 +258,10 @@ class MonteCarloFlow(ABC):
         result = self.event()
         return result, pow(result, 2)
 
-    def _can_run_vectorial(self):
+    def _can_run_vectorial(self, expected_shape=None):
         """Accepting vectorial integrands depends on the algorithm,
         if an algorithm can run on vectorial algorithms it should implement this method and return True"""
-        return False
+        return self._CAN_RUN_VECTORIAL
 
     #### Integration management
     def set_seed(self, seed):
@@ -570,7 +572,7 @@ class MonteCarloFlow(ABC):
             if len(res_shape) == 2:
                 self._vectorial = True
                 expected_shape = res_tmp.reshape(event_size, -1).shape
-                if not self._can_run_vectorial():
+                if not self._can_run_vectorial(expected_shape):
                     raise NotImplementedError(
                         f"""The {self.__class__.__name__} algorithm does not support vectorial integrands
 if you believe this to be a bug please open an issue in https://github.com/N3PDF/vegasflow/issues"""

--- a/src/vegasflow/monte_carlo.py
+++ b/src/vegasflow/monte_carlo.py
@@ -560,7 +560,8 @@ class MonteCarloFlow(ABC):
 
         if check:
             event_size = 23
-            test_array, wgt, _ = self.generate_random_array(event_size)
+            test_array = tf.random.uniform((event_size, self.n_dim), dtype=DTYPE)
+            wgt = tf.random.uniform((event_size,), dtype=DTYPE)
             res_tmp = new_integrand(test_array, weight=wgt).numpy()
             res_shape = res_tmp.shape
 

--- a/src/vegasflow/plain.py
+++ b/src/vegasflow/plain.py
@@ -20,12 +20,15 @@ class PlainFlow(MonteCarloFlow):
 
         # Generate all random number for this iteration
         rnds, _, xjac = self._generate_random_array(n_events)
+
         # Compute the integrand
         tmp = integrand(rnds, weight=xjac) * xjac
         tmp2 = tf.square(tmp)
-        # Accumulate the current result
-        res = tf.reduce_sum(tmp)
-        res2 = tf.reduce_sum(tmp2)
+
+        # Accommodate multidimensional output by ensuring that only the event axis is accumulated
+        res = tf.reduce_sum(tmp, axis=0)
+        res2 = tf.reduce_sum(tmp2, axis=0)
+
         return res, res2
 
     def _run_iteration(self):
@@ -35,6 +38,9 @@ class PlainFlow(MonteCarloFlow):
         err_tmp2 = (res2 - tf.square(res)) / (self.n_events - fone)
         sigma = tf.sqrt(tf.maximum(err_tmp2, fzero))
         return res, sigma
+
+    def _can_run_vectorial(self):
+        return True
 
 
 def plain_wrapper(*args, **kwargs):

--- a/src/vegasflow/plain.py
+++ b/src/vegasflow/plain.py
@@ -12,6 +12,8 @@ class PlainFlow(MonteCarloFlow):
     Simple Monte Carlo integrator.
     """
 
+    _CAN_RUN_VECTORIAL = True
+
     def _run_event(self, integrand, ncalls=None):
         if ncalls is None:
             n_events = self.n_events
@@ -38,9 +40,6 @@ class PlainFlow(MonteCarloFlow):
         err_tmp2 = (res2 - tf.square(res)) / (self.n_events - fone)
         sigma = tf.sqrt(tf.maximum(err_tmp2, fzero))
         return res, sigma
-
-    def _can_run_vectorial(self):
-        return True
 
 
 def plain_wrapper(*args, **kwargs):

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -9,12 +9,12 @@ import json
 import tempfile
 import pytest
 import numpy as np
-import tensorflow as tf
-from vegasflow.configflow import DTYPE
+from vegasflow.configflow import DTYPE, run_eager
 from vegasflow.vflow import VegasFlow
 from vegasflow.plain import PlainFlow
 from vegasflow.vflowplus import VegasFlowPlus
 from vegasflow import plain_sampler, vegas_sampler
+import tensorflow as tf
 
 # Test setup
 dim = 2
@@ -67,7 +67,7 @@ def check_is_one(result, sigmas=3):
 
 
 def test_VegasFlow():
-    """ Test VegasFlow class, importance sampling algorithm"""
+    """Test VegasFlow class, importance sampling algorithm"""
     for mode in range(4):
         vegas_instance = instance_and_compile(VegasFlow, mode)
         _ = vegas_instance.run_integration(n_iter)
@@ -92,7 +92,7 @@ def test_VegasFlow():
 
 
 def test_VegasFlow_save_grid():
-    """ Test the grid saving feature of vegasflow """
+    """Test the grid saving feature of vegasflow"""
     tmp_filename = tempfile.mktemp()
     vegas_instance = instance_and_compile(VegasFlow)
     # Run an iteration so the grid is not trivial
@@ -141,7 +141,7 @@ def test_VegasFlow_load_grid():
 
 
 def test_PlainFlow():
-    # TODO: move the loop to hypothesis...
+    # We could use hypothesis here instead of this loop
     for mode in range(4):
         plain_instance = instance_and_compile(PlainFlow, mode)
         result = plain_instance.run_integration(n_iter)
@@ -177,15 +177,17 @@ def test_rng_generation(n_events=100):
     v = vegas_sampler(example_integrand, dim, n_events, training_steps=2)
     _ = helper_rng_tester(v, n_events)
 
+
 def test_VegasFlowPlus_ADAPTIVE_SAMPLING():
-    """ Test Vegasflow with Adaptive Sampling on (the default) """
+    """Test Vegasflow with Adaptive Sampling on (the default)"""
     for mode in range(4):
         vflowplus_instance = instance_and_compile(VegasFlowPlus, mode)
         result = vflowplus_instance.run_integration(n_iter)
         check_is_one(result)
 
+
 def test_VegasFlowPlus_NOT_ADAPTIVE_SAMPLING():
-    """ Test Vegasflow with Adaptive Sampling off (non-default) """
+    """Test Vegasflow with Adaptive Sampling off (non-default)"""
     vflowplus_instance = VegasFlowPlus(dim, ncalls, adaptive=False)
     vflowplus_instance.compile(example_integrand)
     result = vflowplus_instance.run_integration(n_iter)

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 
 # Test setup
 dim = 2
-ncalls = np.int32(1e4)
+ncalls = np.int32(1e3)
 n_iter = 4
 
 
@@ -34,24 +34,24 @@ def example_integrand(xarr, weight=None):
     return pref * tf.exp(-coef)
 
 
-def instance_and_compile(Integrator, mode=0):
+def instance_and_compile(Integrator, mode=0, integrand_function=example_integrand):
     """Wrapper for convenience"""
     if mode == 0:
-        integrand = example_integrand
+        integrand = integrand_function
     elif mode == 1:
 
         def integrand(xarr, n_dim=None):
-            return example_integrand(xarr)
+            return integrand_function(xarr)
 
     elif mode == 2:
 
         def integrand(xarr):
-            return example_integrand(xarr)
+            return integrand_function(xarr)
 
     elif mode == 3:
 
         def integrand(xarr, n_dim=None, weight=None):
-            return example_integrand(xarr, weight=None)
+            return integrand_function(xarr, weight=None)
 
     int_instance = Integrator(dim, ncalls)
     int_instance.compile(integrand)
@@ -61,7 +61,7 @@ def instance_and_compile(Integrator, mode=0):
 def check_is_one(result, sigmas=3):
     """Wrapper for convenience"""
     res = result[0]
-    err = result[1] * sigmas
+    err = np.mean(result[1] * sigmas)
     # Check that it passes by {sigmas} number of sigmas
     np.testing.assert_allclose(res, 1.0, atol=err)
 

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 
 # Test setup
 dim = 2
-ncalls = np.int32(1e3)
+ncalls = np.int32(1e4)
 n_iter = 4
 
 

--- a/src/vegasflow/tests/test_algs.py
+++ b/src/vegasflow/tests/test_algs.py
@@ -66,14 +66,20 @@ def check_is_one(result, sigmas=3):
     np.testing.assert_allclose(res, 1.0, atol=err)
 
 
-def test_VegasFlow():
+@pytest.mark.parametrize("mode", range(4))
+def test_VegasFlow(mode):
     """Test VegasFlow class, importance sampling algorithm"""
-    for mode in range(4):
-        vegas_instance = instance_and_compile(VegasFlow, mode)
-        _ = vegas_instance.run_integration(n_iter)
-        vegas_instance.freeze_grid()
-        result = vegas_instance.run_integration(n_iter)
-        check_is_one(result)
+    vegas_instance = instance_and_compile(VegasFlow, mode)
+    _ = vegas_instance.run_integration(n_iter)
+    vegas_instance.freeze_grid()
+    result = vegas_instance.run_integration(n_iter)
+    check_is_one(result)
+
+
+def test_VegasFlow_grid_management():
+    vegas_instance = instance_and_compile(VegasFlow, 1)
+    _ = vegas_instance.run_integration(n_iter)
+    vegas_instance.freeze_grid()
 
     # Change the number of events
     vegas_instance.n_events = 2 * ncalls
@@ -140,15 +146,18 @@ def test_VegasFlow_load_grid():
         vegas_instance.load_grid(file_name=tmp_filename)
 
 
-def test_PlainFlow():
-    # We could use hypothesis here instead of this loop
-    for mode in range(4):
-        plain_instance = instance_and_compile(PlainFlow, mode)
-        result = plain_instance.run_integration(n_iter)
-        check_is_one(result)
+@pytest.mark.parametrize("mode", range(4))
+def test_PlainFlow(mode):
+    plain_instance = instance_and_compile(PlainFlow, mode)
+    result = plain_instance.run_integration(n_iter)
+    check_is_one(result)
 
-    # Use the last instance to check that changing the number of events
-    # don't change the result
+
+def test_PlainFlow_change_nevents():
+    plain_instance = instance_and_compile(PlainFlow, 0)
+    result = plain_instance.run_integration(n_iter)
+    check_is_one(result)
+
     plain_instance.n_events = 2 * ncalls
     new_result = plain_instance.run_integration(n_iter)
     check_is_one(new_result)
@@ -178,12 +187,12 @@ def test_rng_generation(n_events=100):
     _ = helper_rng_tester(v, n_events)
 
 
-def test_VegasFlowPlus_ADAPTIVE_SAMPLING():
+@pytest.mark.parametrize("mode", range(4))
+def test_VegasFlowPlus_ADAPTIVE_SAMPLING(mode):
     """Test Vegasflow with Adaptive Sampling on (the default)"""
-    for mode in range(4):
-        vflowplus_instance = instance_and_compile(VegasFlowPlus, mode)
-        result = vflowplus_instance.run_integration(n_iter)
-        check_is_one(result)
+    vflowplus_instance = instance_and_compile(VegasFlowPlus, mode)
+    result = vflowplus_instance.run_integration(n_iter)
+    check_is_one(result)
 
 
 def test_VegasFlowPlus_NOT_ADAPTIVE_SAMPLING():

--- a/src/vegasflow/tests/test_gradients.py
+++ b/src/vegasflow/tests/test_gradients.py
@@ -2,10 +2,12 @@
     Tests the gradients of the different algorithms
 """
 
+import numpy as np
+from pytest import mark
+
 from vegasflow import float_me, run_eager
 from vegasflow import VegasFlow, VegasFlowPlus, PlainFlow
 import tensorflow as tf
-import numpy as np
 
 
 def generate_integrand(variable):
@@ -70,17 +72,12 @@ def wrapper_test(iclass, x_point=5.0, alpha=10, integrator_kwargs=None):
     np.testing.assert_allclose(grad_1 * alpha, grad_2, rtol=1e-2)
 
 
-def test_gradient_Vegasflow():
-    """ "Test one can compile and generate gradients with VegasFlow"""
-    wrapper_test(VegasFlow)
+@mark.parametrize("algorithm", [VegasFlowPlus, VegasFlow, PlainFlow])
+def test_gradient(algorithm):
+    """ "Test one can compile and generate gradients with the different algorithms"""
+    wrapper_test(algorithm)
 
 
-def test_gradient_VegasflowPlus():
+def test_gradient_VegasflowPlus_adaptive():
     """ "Test one can compile and generate gradients with VegasFlowPlus"""
-    wrapper_test(VegasFlowPlus)
     wrapper_test(VegasFlowPlus, integrator_kwargs={"adaptive": True})
-
-
-def test_gradient_PlainFlow():
-    """ "Test one can compile and generate gradients with PlainFlow"""
-    wrapper_test(PlainFlow)

--- a/src/vegasflow/tests/test_misc.py
+++ b/src/vegasflow/tests/test_misc.py
@@ -1,0 +1,29 @@
+"""
+    Miscellaneous tests that don't really fit anywhere else
+"""
+import pytest
+from vegasflow import VegasFlow, VegasFlowPlus, PlainFlow
+import tensorflow as tf
+
+from .test_algs import instance_and_compile, check_is_one
+
+
+def _multidim_integrand(xarr, weight=None):
+    res = tf.square((xarr - 1.0) ** 2)
+    return tf.exp(-res) / 0.845
+
+
+def test_working_vectorial():
+    """Check that the algorithms that accept integrating vectorial functions can really do so"""
+    for alg in [VegasFlow, PlainFlow]:
+        for mode in range(4):
+            inst = instance_and_compile(alg, mode=mode, integrand_function=_multidim_integrand)
+            result = inst.run_integration(2)
+            check_is_one(result)
+
+
+def test_notworking_vectorial():
+    """Check that the algorithms that do not accept vectorial functions fail appropriately"""
+    for alg in [VegasFlowPlus]:
+        with pytest.raises(NotImplementedError):
+            inst = instance_and_compile(alg, integrand_function=_multidim_integrand)

--- a/src/vegasflow/tests/test_misc.py
+++ b/src/vegasflow/tests/test_misc.py
@@ -2,6 +2,7 @@
     Miscellaneous tests that don't really fit anywhere else
 """
 import pytest
+
 from vegasflow import VegasFlow, VegasFlowPlus, PlainFlow
 import tensorflow as tf
 
@@ -23,20 +24,20 @@ def _wrong_vector_integrand(xarr):
     return tf.transpose(xarr)
 
 
-def test_working_vectorial():
+@pytest.mark.parametrize("mode", range(4))
+@pytest.mark.parametrize("alg", [VegasFlow, PlainFlow])
+def test_working_vectorial(alg, mode):
     """Check that the algorithms that accept integrating vectorial functions can really do so"""
-    for alg in [VegasFlow, PlainFlow]:
-        for mode in range(4):
-            inst = instance_and_compile(alg, mode=mode, integrand_function=_vector_integrand)
-            result = inst.run_integration(2)
-            check_is_one(result)
+    inst = instance_and_compile(alg, mode=mode, integrand_function=_vector_integrand)
+    result = inst.run_integration(2)
+    check_is_one(result, sigmas=4)
 
 
-def test_notworking_vectorial():
+@pytest.mark.parametrize("alg", [VegasFlowPlus])
+def test_notworking_vectorial(alg):
     """Check that the algorithms that do not accept vectorial functions fail appropriately"""
-    for alg in [VegasFlowPlus]:
-        with pytest.raises(NotImplementedError):
-            _ = instance_and_compile(alg, integrand_function=_vector_integrand)
+    with pytest.raises(NotImplementedError):
+        _ = instance_and_compile(alg, integrand_function=_vector_integrand)
 
 
 def test_check_wrong_main_dimension():
@@ -47,8 +48,8 @@ def test_check_wrong_main_dimension():
         inst.compile(_vector_integrand)
 
 
-def test_wrong_shape():
+@pytest.mark.parametrize("wrong_fun", [_wrong_vector_integrand, _wrong_integrand])
+def test_wrong_shape(wrong_fun):
     """Check that an error is raised by the compilation if the integrand has the wrong shape"""
-    for wrong_fun in [_wrong_vector_integrand, _wrong_integrand]:
-        with pytest.raises(ValueError):
-            _ = instance_and_compile(PlainFlow, integrand_function=wrong_fun)
+    with pytest.raises(ValueError):
+        _ = instance_and_compile(PlainFlow, integrand_function=wrong_fun)

--- a/src/vegasflow/tests/test_misc.py
+++ b/src/vegasflow/tests/test_misc.py
@@ -8,16 +8,26 @@ import tensorflow as tf
 from .test_algs import instance_and_compile, check_is_one
 
 
-def _multidim_integrand(xarr, weight=None):
+def _vector_integrand(xarr, weight=None):
     res = tf.square((xarr - 1.0) ** 2)
     return tf.exp(-res) / 0.845
+
+
+def _wrong_integrand(xarr):
+    """Integrand with the wrong output shape"""
+    return tf.reduce_sum(xarr)
+
+
+def _wrong_vector_integrand(xarr):
+    """Vector integrand with the wrong output shape"""
+    return tf.transpose(xarr)
 
 
 def test_working_vectorial():
     """Check that the algorithms that accept integrating vectorial functions can really do so"""
     for alg in [VegasFlow, PlainFlow]:
         for mode in range(4):
-            inst = instance_and_compile(alg, mode=mode, integrand_function=_multidim_integrand)
+            inst = instance_and_compile(alg, mode=mode, integrand_function=_vector_integrand)
             result = inst.run_integration(2)
             check_is_one(result)
 
@@ -26,4 +36,19 @@ def test_notworking_vectorial():
     """Check that the algorithms that do not accept vectorial functions fail appropriately"""
     for alg in [VegasFlowPlus]:
         with pytest.raises(NotImplementedError):
-            inst = instance_and_compile(alg, integrand_function=_multidim_integrand)
+            _ = instance_and_compile(alg, integrand_function=_vector_integrand)
+
+
+def test_check_wrong_main_dimension():
+    """Check that an error is raised  by VegasFlow
+    if the main dimension is > than the dimensionality of the integrand"""
+    inst = VegasFlow(3, 100, main_dimension=5)
+    with pytest.raises(ValueError):
+        inst.compile(_vector_integrand)
+
+
+def test_wrong_shape():
+    """Check that an error is raised by the compilation if the integrand has the wrong shape"""
+    for wrong_fun in [_wrong_vector_integrand, _wrong_integrand]:
+        with pytest.raises(ValueError):
+            _ = instance_and_compile(PlainFlow, integrand_function=wrong_fun)

--- a/src/vegasflow/tests/test_utils.py
+++ b/src/vegasflow/tests/test_utils.py
@@ -13,13 +13,13 @@ from vegasflow.utils import generate_condition_function
 def test_consume_array_into_indices():
     # Select the size
     size_in = np.random.randint(5, 100)
-    size_out = np.random.randint(1, size_in-3)
+    size_out = np.random.randint(1, size_in - 3)
     # Generate the input array and the indices
     input_array = np.random.rand(size_in)
     indices = np.random.randint(0, size_out, size=size_in)
     # Make them into TF
     tf_input = tf.constant(input_array)
-    tf_indx = tf.constant(indices.reshape(-1,1), dtype=DTYPEINT)
+    tf_indx = tf.constant(indices.reshape(-1, 1), dtype=DTYPEINT)
     result = consume_array_into_indices(tf_input, tf_indx, int_me(size_out))
     py_result = py_consume_array_into_indices(tf_input, tf_indx, size_out)
     np.testing.assert_array_equal(result, py_result)
@@ -31,21 +31,23 @@ def test_consume_array_into_indices():
         check_result[i] += val
     np.testing.assert_allclose(check_result, result)
 
+
 def util_check(np_mask, tf_mask, tf_ind):
     np.testing.assert_array_equal(np_mask, tf_mask)
     # Numpy returns things the other way around
     np_indices = np.array(np_mask.nonzero()).T
     np.testing.assert_array_equal(np_indices, tf_ind)
 
+
 def test_generate_condition_function():
-    """ Tests generate_condition_function and its errors """
-    masks = 4 # Always > 2
+    """Tests generate_condition_function and its errors"""
+    masks = 4  # Always > 2
     vals = 15
     np_masks = np.random.randint(2, size=(masks, vals), dtype=bool)
     tf_masks = [tf.constant(i, dtype=tf.bool) for i in np_masks]
     # Generate the functions for and and or
-    f_and = generate_condition_function(masks, 'and')
-    f_or = generate_condition_function(masks, 'or')
+    f_and = generate_condition_function(masks, "and")
+    f_or = generate_condition_function(masks, "or")
     # Get the numpy and tf results
     np_ands = np.all(np_masks, axis=0)
     np_ors = np.any(np_masks, axis=0)
@@ -55,16 +57,16 @@ def test_generate_condition_function():
     util_check(np_ands, tf_ands, idx_ands)
     util_check(np_ors, tf_ors, idx_ors)
     # Check a combination
-    f_comb = generate_condition_function(3, ['and', 'or'])
+    f_comb = generate_condition_function(3, ["and", "or"])
     np_comb = np_masks[0] & np_masks[1] | np_masks[2]
     tf_comb, idx_comb = f_comb(*tf_masks[:3])
     util_check(np_comb, tf_comb, idx_comb)
     # Check failures
     with pytest.raises(ValueError):
-        generate_condition_function(1, 'and')
+        generate_condition_function(1, "and")
     with pytest.raises(ValueError):
-        generate_condition_function(5, 'bad_condition')
+        generate_condition_function(5, "bad_condition")
     with pytest.raises(ValueError):
-        generate_condition_function(5, ['or', 'and'])
+        generate_condition_function(5, ["or", "and"])
     with pytest.raises(ValueError):
-        generate_condition_function(3, ['or', 'bad_condition'])
+        generate_condition_function(3, ["or", "bad_condition"])

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -218,7 +218,7 @@ class VegasFlow(MonteCarloFlow):
     Implementation of the important sampling algorithm from Vegas
     """
 
-    def __init__(self, n_dim, n_events, train=True, **kwargs):
+    def __init__(self, n_dim, n_events, train=True, main_dimension=0, **kwargs):
         super().__init__(n_dim, n_events, **kwargs)
 
         # If training is True, the grid will be changed after every iteration
@@ -230,6 +230,7 @@ class VegasFlow(MonteCarloFlow):
         subdivision_np = np.linspace(0, 1, self.grid_bins)
         divisions_np = subdivision_np.repeat(n_dim).reshape(-1, n_dim).T
         self.divisions = tf.Variable(divisions_np, dtype=DTYPE)
+        self._main_dimension = main_dimension
 
     def make_differentiable(self):
         """Freeze the grid if the function is to be called within a graph"""
@@ -390,7 +391,9 @@ class VegasFlow(MonteCarloFlow):
         x, ind, xjac = self._generate_random_array(n_events)
 
         # Now compute the integrand
-        tmp = xjac * integrand(x, weight=xjac)
+        int_result = integrand(x, weight=xjac)
+
+        tmp = xjac * int_result
         tmp2 = tf.square(tmp)
 
         # Compute the final result for this step

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -215,7 +215,18 @@ def refine_grid_per_dimension(t_res_sq, subdivisions):
 ####### VegasFlow
 class VegasFlow(MonteCarloFlow):
     """
-    Implementation of the important sampling algorithm from Vegas
+    Implementation of the important sampling algorithm from Vegas.
+
+    Parameters
+    ----------
+        n_dim: int
+            number of dimensions to be integrated
+        n_events: int
+            number of events per iteration
+        train: bool
+            whether to train the grid
+        main_dimension: int
+            in case of vectorial output, main dimenison in which to train
     """
 
     def __init__(self, n_dim, n_events, train=True, main_dimension=0, **kwargs):
@@ -231,6 +242,10 @@ class VegasFlow(MonteCarloFlow):
         divisions_np = subdivision_np.repeat(n_dim).reshape(-1, n_dim).T
         self.divisions = tf.Variable(divisions_np, dtype=DTYPE)
         self._main_dimension = main_dimension
+
+    def _can_run_vectorial(self):
+        # only implemented for the main class at the moment, not for children
+        return self.__class__.__name__ == "VegasFlow"
 
     def make_differentiable(self):
         """Freeze the grid if the function is to be called within a graph"""
@@ -393,12 +408,19 @@ class VegasFlow(MonteCarloFlow):
         # Now compute the integrand
         int_result = integrand(x, weight=xjac)
 
+        if self._vectorial:
+            xjac = tf.reshape(xjac, (-1, 1))
         tmp = xjac * int_result
         tmp2 = tf.square(tmp)
 
         # Compute the final result for this step
-        res = tf.reduce_sum(tmp)
-        res2 = tf.reduce_sum(tmp2)
+        res = tf.reduce_sum(tmp, axis=0)
+        res2 = tf.reduce_sum(tmp2, axis=0)
+
+        # If this is a vectorial integrnad, make sure that only the main dimenison
+        # is used for the grid training
+        if self._vectorial:
+            tmp2 = tmp2[:, self._main_dimension]
 
         arr_res2 = self._importance_sampling_array_filling(tmp2, ind)
 

--- a/src/vegasflow/vflow.py
+++ b/src/vegasflow/vflow.py
@@ -243,8 +243,13 @@ class VegasFlow(MonteCarloFlow):
         self.divisions = tf.Variable(divisions_np, dtype=DTYPE)
         self._main_dimension = main_dimension
 
-    def _can_run_vectorial(self):
+    def _can_run_vectorial(self, expected_shape):
         # only implemented for the main class at the moment, not for children
+        if self._main_dimension >= expected_shape[-1]:
+            raise ValueError(
+                f"""The main dimension index ({self._main_dimension}) is greater than the dimensionality of the output ({expected_shape[-1]}).
+            Remember that arrays in python are 0-indexed!"""
+            )
         return self.__class__.__name__ == "VegasFlow"
 
     def make_differentiable(self):

--- a/src/vegasflow/vflowplus.py
+++ b/src/vegasflow/vflowplus.py
@@ -143,7 +143,7 @@ class VegasFlowPlus(VegasFlow):
     def make_differentiable(self):
         """Overrides make_differentiable to make sure the runner has a reference to n_ev"""
         runner = super().make_differentiable()
-        return partial(runner, n_ev = self.n_ev)
+        return partial(runner, n_ev=self.n_ev)
 
     def redistribute_samples(self, arr_var):
         """Receives an array with the variance of the integrand in each


### PR DESCRIPTION
This feature could already be implemented by using the same techniques as in the example for multiple integrals: https://github.com/N3PDF/vegasflow/blob/master/examples/multiple_integrals.py

but since this exploits the tensor structure of all TensorFlow quantities I thought it would be nice to have it "official supported". Specially since there are examples of this already in the wild.

Need to
- [x] Ensure that this doesn't harm performance for normal integrations
- [x] Add docs to explain how it should be used (and possible caveats)
- [x] Ensure the test include the new features